### PR TITLE
feat: Make chunk size configurable via env var to avoid token limit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All configuration is managed via environment variables.
 | `ANTHROPIC_API_KEY`        | API key for Anthropic (Claude)                                                                        |                          |
 | `RAG_PROVIDER`             | RAG backend orchestrator: `vectorstore` (custom) or `langchain`                                       | `vectorstore`            |
 | `RAG_DOCS_PATH`            | Filesystem path to directory with context documents for RAG ingestion (`.txt` and `.pdf` only).       | `/docs`                  |
+| `RAG_CHUNK_SIZE`           | Max token/character count per document chunk in RAG                                                   | `1000`                   |
 | `VECTOR_STORE`             | Vector store provider for RAG: `pinecone`, `redis`                                                    | `redis`                  |
 | `VECTOR_INDEX_NAME`        | Index name for both Pinecone and Redis vector stores                                                  | `hologram-ia`            |
 | `PINECONE_API_KEY`         | API key for Pinecone vector store                                                                     | `pcsk_xxx`               |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@langchain/openai": "^0.5.10",
     "@langchain/pinecone": "^0.2.0",
     "@langchain/redis": "^0.1.0",
+    "@langchain/textsplitters": "^0.1.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@langchain/redis':
         specifier: ^0.1.0
         version: 0.1.1(@langchain/core@0.3.58(openai@4.104.0(ws@8.18.2)(zod@3.25.63)))
+      '@langchain/textsplitters':
+        specifier: ^0.1.0
+        version: 0.1.0(@langchain/core@0.3.58(openai@4.104.0(ws@8.18.2)(zod@3.25.63)))
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -2412,6 +2415,7 @@ packages:
 
   '@sphereon/kmp-mdl-mdoc@0.2.0-SNAPSHOT.22':
     resolution: {integrity: sha512-uAZZExVy+ug9JLircejWa5eLtAZ7bnBP6xb7DO2+86LRsHNLh2k2jMWJYxp+iWtGHTsh6RYsZl14ScQLvjiQ/A==}
+    bundledDependencies: []
 
   '@sphereon/pex-models@2.3.2':
     resolution: {integrity: sha512-foFxfLkRwcn/MOp/eht46Q7wsvpQGlO7aowowIIb5Tz9u97kYZ2kz6K2h2ODxWuv5CRA7Q0MY8XUBGE2lfOhOQ==}
@@ -11106,7 +11110,7 @@ snapshots:
 
   dotenv-expand@11.0.7:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.5.0
     optional: true
 
   dotenv-expand@12.0.1:

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -169,4 +169,13 @@ export default registerAs('appConfig', () => ({
    *   ]
    */
   llmToolsConfig: process.env.LLM_TOOLS_CONFIG || '[]',
+
+  /**
+   * Maximum size (in characters or tokens) for each document chunk when splitting documents
+   * for Retrieval-Augmented Generation (RAG) processing.
+   *
+   * This value can be configured via the `RAG_CHUNK_SIZE` environment variable.
+   * If not set, it defaults to 1000.
+   */
+  ragChunkSize: Number(process.env.RAG_CHUNK_SIZE) || 1000,
 }))


### PR DESCRIPTION
- Add RAG_CHUNK_SIZE env variable to control document chunk size during ingestion.
- Default chunk size set to 1000, can be customized per deployment.
- Update LangchainRagService and appConfig to use dynamic chunking.
- Add jsdoc and documentation for new environment variable.
- Mitigate OpenAI context window errors for large documents in RAG ingestion.