### PR TITLE
ci: add .releaserc.json with semantic-release configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,38 +36,6 @@ jobs:
 
       - uses: codfish/semantic-release-action@v3
         id: semantic
-        with:
-          branches: |
-            [
-              'release',
-              { 
-                name: 'main',
-                prerelease: 'dev'
-              }
-            ]
-          plugins: |
-            [
-              [
-                "@semantic-release/commit-analyzer",
-                {
-                  "preset": "angular",
-                  "releaseRules": [
-                    {
-                      "type": "refactor",
-                      "release": "patch"
-                    }
-                  ]
-                }
-              ],
-              [
-                "@semantic-release/npm",
-                {
-                  "npmPublish": false
-                }
-              ],
-              "@semantic-release/release-notes-generator",
-            ]
-
       - name: Log in to Docker Hub
         if: steps.semantic.outputs.new-release-published == 'true'
         run: |

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,30 @@
+{
+  "branches": [
+    "release",
+    {
+      "name": "main",
+      "prerelease": "dev"
+    }
+  ],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {
+            "type": "refactor",
+            "release": "patch"
+          }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    "@semantic-release/release-notes-generator"
+  ]
+}


### PR DESCRIPTION
This PR centralizes and enhances our `semantic-release` setup in line with the [official documentation](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches):

- **Adds** a `.releaserc.json` file at the repository root, containing the configuration stablished into cd
- **Simplifies** the `codfish/semantic-release-action` step in the CD workflow by removing the inline `branches` and `plugins` inputs.