### PR TITLE
fix: Fix image name to hologram-generic-ai-agent in stable-release 

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,7 +1,7 @@
 name: Continuous Deployment (Stable Release)
 
 env:
-  IMAGE_NAME: hologram-welcome-ai-agent-app
+  IMAGE_NAME: hologram-generic-ai-agent-app
 
 on:
   push:


### PR DESCRIPTION
In the previous commit, the container image was not renamed in the stable-release workflow