### PR TITLE
fix: wrap stats deployment in enabled condition

### DIFF
--- a/charts/templates/stats-deployment.yaml
+++ b/charts/templates/stats-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.stats.enabled }}
 {{- if .Values.stats.secret }}
 apiVersion: v1
 kind: Secret
@@ -98,3 +99,4 @@ spec:
                   name: stats-secret
                   key: {{ $key }}
             {{- end }}
+{{- end }}


### PR DESCRIPTION
Stats resources (Service, Ingress, StatefulSet) were always deployed regardless of stats.enabled value. Now respects the enabled flag, matching how artemis-deployment.yaml works.