### PR TITLE
fix: proactively connect user-controlled MCP servers before LLM runs

### DIFF
--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -154,6 +154,12 @@ export class LlmService implements OnModuleInit {
     try {
       const today = new Date().toISOString().split('T')[0]
 
+      // Proactively connect user-controlled MCP servers so tools are discovered
+      // before the agent runs (breaks chicken-and-egg after pod restart)
+      if (session?.userName) {
+        await this.mcpService.ensureUserConnections(session.userName)
+      }
+
       // Check if MCP tools have been lazily discovered since last call
       await this.refreshMcpTools()
 

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -480,6 +480,44 @@ export class McpService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Proactively establishes per-user connections for all user-controlled servers
+   * where the user has saved config. This ensures lazy tool discovery happens
+   * before the LLM agent runs, breaking the chicken-and-egg problem where tools
+   * can't be called because they haven't been discovered yet.
+   */
+  async ensureUserConnections(avatarName: string): Promise<void> {
+    for (const def of this.serverDefs) {
+      if (def.accessMode !== 'user-controlled') continue
+
+      const cacheKey = `${avatarName}:${def.name}`
+      if (this.userConnections.has(cacheKey)) continue
+
+      const userConfig = await this.mcpConfigService.getConfig(avatarName, def.name)
+      if (!userConfig) continue
+
+      if (!def.url || !def.userConfig?.fields) continue
+
+      const headers = this.buildUserHeaders(def, userConfig)
+      try {
+        const client = new Client({ name: `hologram-agent/${def.name}/${avatarName}`, version: '1.0.0' })
+        const transport = new StreamableHTTPClientTransport(new URL(def.url), {
+          requestInit: { headers },
+        })
+        await client.connect(transport)
+        const conn: McpConnection = { name: def.name, client, transport }
+        this.userConnections.set(cacheKey, conn)
+        this.logger.log(`[MCP_USER] Proactively connected avatar="${avatarName}" server="${def.name}".`)
+
+        if (!this.serverToolCache.has(def.name)) {
+          await this.discoverAndCacheTools(conn, def.name)
+        }
+      } catch (err) {
+        this.logger.warn(`[MCP_USER] Proactive connection failed for avatar="${avatarName}" server="${def.name}": ${err}`)
+      }
+    }
+  }
+
+  /**
    * Invalidates cached per-user connections for a specific avatar + server.
    * Call this when the user updates their credentials.
    */


### PR DESCRIPTION
After pod restart, user-controlled MCP servers had no cached tools because lazy discovery only happened when a tool was called — but the LLM couldn't call tools it didn't know about (chicken-and-egg).

ensureUserConnections() now runs before each generate() call, re-establishing per-user connections from saved DB configs and triggering tool discovery so refreshMcpTools() can bind them to the LLM agent.