### PR TITLE
feat: support OpenAI-compatible API providers via OPENAI_BASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A modular, multi-language AI agent built with NestJS for the Hologram + Verana e
 ## 🚀 Overview
 
 - **Personalized AI welcome** — sends a greeting message when a user connects via Hologram
-- **Multi-LLM support** — OpenAI, Ollama, Anthropic with configurable model, temperature, and tokens
+- **Multi-LLM support** — OpenAI, Ollama, Anthropic + any OpenAI-compatible API (Kimi, DeepSeek, Groq, Together AI, etc.)
 - **RAG** — Retrieval Augmented Generation with Pinecone or Redis vector stores
 - **MCP integration** — connect to remote MCP servers (e.g. GitHub Copilot MCP) and expose their tools to the LLM agent
 - **Per-user MCP credentials** — users configure their own tokens via an in-chat flow; stored with AES-256-GCM encryption
@@ -394,7 +394,8 @@ Full design specification: [`docs/rbac-approval-spec.md`](./docs/rbac-approval-s
 | `OPENAI_MODEL` | OpenAI model | `gpt-4o-mini` |
 | `OPENAI_TEMPERATURE` | Temperature (0–1) | `0.3` |
 | `OPENAI_MAX_TOKENS` | Max tokens per completion | `512` |
-| `OLLAMA_ENDPOINT` | Ollama endpoint | `http://ollama:11435` |
+| `OPENAI_BASE_URL` | Base URL for OpenAI-compatible APIs (Kimi, DeepSeek, Groq, etc.) | |
+| `OLLAMA_ENDPOINT` | Ollama endpoint | `http://ollama:11434` |
 | `OLLAMA_MODEL` | Ollama model | `llama3` |
 | `ANTHROPIC_API_KEY` | Anthropic API key | |
 | `RAG_PROVIDER` | RAG backend: `vectorstore` or `langchain` | `vectorstore` |

--- a/docs/agent-pack-schema.md
+++ b/docs/agent-pack-schema.md
@@ -94,10 +94,11 @@ languages:
 
 | Field          | Type           | Env override          | Default      | Description                          |
 | -------------- | -------------- | --------------------- | ------------ | ------------------------------------ |
-| `provider`     | string         | `LLM_PROVIDER`        | `openai`     | LLM provider (`openai`, `ollama`, `anthropic`). |
+| `provider`     | string         | `LLM_PROVIDER`        | `openai`     | LLM provider (`openai`, `ollama`, `anthropic`). Use `openai` for any OpenAI-compatible API. |
 | `model`        | string         | `OPENAI_MODEL`        | `gpt-4o-mini`| Model name.                          |
 | `temperature`  | number/string  | `OPENAI_TEMPERATURE`  | `0.3`        | Sampling temperature (0–1).          |
 | `maxTokens`    | number/string  | `OPENAI_MAX_TOKENS`   | `512`        | Max tokens per completion.           |
+| `baseUrl`      | string         | `OPENAI_BASE_URL`     | —            | Base URL for OpenAI-compatible APIs (e.g., Kimi, DeepSeek, Groq, Together AI). |
 | `agentPrompt`  | string         | `AGENT_PROMPT`        | —            | Default agent prompt / persona.      |
 | `verbose`      | boolean/string | —                     | —            | Enable verbose LLM logging.          |
 
@@ -110,6 +111,38 @@ llm:
   agentPrompt: |
     You are an AI financial assistant...
 ```
+
+#### Using OpenAI-compatible providers
+
+Any API that follows the OpenAI chat completions format can be used by setting `provider: openai` and providing a `baseUrl`:
+
+```yaml
+# Kimi (Moonshot AI)
+llm:
+  provider: openai
+  model: moonshot-v1-8k
+  baseUrl: https://api.moonshot.cn/v1
+
+# DeepSeek
+llm:
+  provider: openai
+  model: deepseek-chat
+  baseUrl: https://api.deepseek.com
+
+# Groq
+llm:
+  provider: openai
+  model: llama-3.3-70b-versatile
+  baseUrl: https://api.groq.com/openai/v1
+
+# Together AI
+llm:
+  provider: openai
+  model: meta-llama/Llama-3-70b-chat-hf
+  baseUrl: https://api.together.xyz/v1
+```
+
+Set the corresponding API key via `OPENAI_API_KEY` (or the agent pack's environment variable resolution).
 
 ---
 

--- a/src/config/agent-pack.loader.ts
+++ b/src/config/agent-pack.loader.ts
@@ -38,6 +38,7 @@ const AgentPackSchema = z
         temperature: z.union([z.number(), z.string()]).optional(),
         maxTokens: z.union([z.number(), z.string()]).optional(),
         agentPrompt: z.string().optional(),
+        baseUrl: z.string().optional(),
         verbose: z.union([z.boolean(), z.string()]).optional(),
       })
       .optional(),
@@ -98,15 +99,17 @@ const AgentPackSchema = z
                   labelKey: z.string().optional(),
                   label: z.string().optional(),
                   action: z.string().optional(),
-                  visibleWhen: z.enum([
-                    'always',
-                    'authenticated',
-                    'unauthenticated',
-                    'configuring',
-                    'notConfiguring',
-                    'hasApprovalRequests',
-                    'hasPendingApprovals',
-                  ]).optional(),
+                  visibleWhen: z
+                    .enum([
+                      'always',
+                      'authenticated',
+                      'unauthenticated',
+                      'configuring',
+                      'notConfiguring',
+                      'hasApprovalRequests',
+                      'hasPendingApprovals',
+                    ])
+                    .optional(),
                   badge: z.string().optional(),
                 }),
               )

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,6 +1,14 @@
 import { registerAs } from '@nestjs/config'
 import { config as dotenvConfig } from 'dotenv'
-import { loadAgentPack, pickBoolean, pickNumber, pickString, resolveRagRemoteUrls, resolveToolsConfig, resolveMcpServers } from './agent-pack.loader'
+import {
+  loadAgentPack,
+  pickBoolean,
+  pickNumber,
+  pickString,
+  resolveRagRemoteUrls,
+  resolveToolsConfig,
+  resolveMcpServers,
+} from './agent-pack.loader'
 
 // Load .env early so resolvePlaceholders() in loadAgentPack() can resolve ${VAR} refs.
 // override: true ensures .env values win over stale shell env vars.
@@ -91,6 +99,13 @@ export default registerAs('appConfig', () => ({
    * OpenAI max tokens per completion.
    */
   openaiMaxTokens: pickNumber('OPENAI_MAX_TOKENS', agentPack?.llm?.maxTokens, 512),
+
+  /**
+   * Base URL for OpenAI-compatible APIs (e.g., Kimi, DeepSeek, Groq, Together AI).
+   * When set, the OpenAI provider will use this URL instead of the default OpenAI endpoint.
+   * Example: https://api.moonshot.cn/v1
+   */
+  openaiBaseUrl: pickString('OPENAI_BASE_URL', agentPack?.llm?.baseUrl, ''),
 
   /**
    * Anthropic API key (required if using Anthropic provider, e.g., Claude).
@@ -200,7 +215,11 @@ export default registerAs('appConfig', () => ({
    * Credential attribute that uniquely identifies the user (e.g., 'name', 'email', 'employeeLogin').
    * Default: 'name' (for avatar credentials)
    */
-  userIdentityAttribute: pickString('USER_IDENTITY_ATTRIBUTE', agentPack?.flows?.authentication?.userIdentityAttribute, 'name'),
+  userIdentityAttribute: pickString(
+    'USER_IDENTITY_ATTRIBUTE',
+    agentPack?.flows?.authentication?.userIdentityAttribute,
+    'name',
+  ),
 
   /**
    * Credential attribute containing the user's role(s).
@@ -219,14 +238,18 @@ export default registerAs('appConfig', () => ({
    * Comma-separated list of identity values matched against userIdentityAttribute.
    */
   adminUsers: process.env.ADMIN_USERS
-    ? process.env.ADMIN_USERS.split(',').map((s: string) => s.trim()).filter(Boolean)
+    ? process.env.ADMIN_USERS.split(',')
+        .map((s: string) => s.trim())
+        .filter(Boolean)
     : (agentPack?.flows?.authentication?.adminUsers ?? []),
 
   /**
    * Legacy: comma-separated list of avatar names that have admin privileges.
    */
   adminAvatars: process.env.ADMIN_AVATARS
-    ? process.env.ADMIN_AVATARS.split(',').map((s: string) => s.trim()).filter(Boolean)
+    ? process.env.ADMIN_AVATARS.split(',')
+        .map((s: string) => s.trim())
+        .filter(Boolean)
     : (agentPack?.flows?.authentication?.adminAvatars ?? []),
 
   /**

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -47,7 +47,13 @@ export class LlmService implements OnModuleInit {
   /** Last known McpService.toolsVersion — used to detect lazy tool discoveries */
   private lastToolsVersion = -1
   /** Raw MCP tool metadata — retained for per-user RBAC filtering */
-  private allMcpToolInfos: { serverName: string; name: string; description?: string; inputSchema: Record<string, unknown>; isPublic: boolean }[] = []
+  private allMcpToolInfos: {
+    serverName: string
+    name: string
+    description?: string
+    inputSchema: Record<string, unknown>
+    isPublic: boolean
+  }[] = []
   /** Wrapped MCP tools indexed by "serverName/toolName" for efficient per-role reuse */
   private mcpToolMap = new Map<string, DynamicStructuredTool>()
   /** Cached RBAC-filtered agents keyed by sorted role-set string */
@@ -126,7 +132,9 @@ export class LlmService implements OnModuleInit {
       if (allMcpTools.length > 0) {
         const pubNames = publicMcpTools.map((t) => t.name)
         const adminOnlyNames = allMcpTools.filter((t) => !pubNames.includes(t.name)).map((t) => t.name)
-        this.logger.log(`MCP tools refreshed: ${allMcpTools.length} total (${pubNames.length} public, ${adminOnlyNames.length} admin-only). toolsVersion=${currentVersion}`)
+        this.logger.log(
+          `MCP tools refreshed: ${allMcpTools.length} total (${pubNames.length} public, ${adminOnlyNames.length} admin-only). toolsVersion=${currentVersion}`,
+        )
       }
 
       // Clear RBAC agent cache since tools have changed
@@ -137,7 +145,9 @@ export class LlmService implements OnModuleInit {
         const { publicAgent, adminAgent } = await this.setupToolAgent(this.publicTools, this.adminTools)
         this.publicAgent = publicAgent
         this.adminAgent = adminAgent
-        this.logger.log(`Tool agents rebuilt: public=${this.publicTools.length} tools, admin=${this.adminTools.length} tools.`)
+        this.logger.log(
+          `Tool agents rebuilt: public=${this.publicTools.length} tools, admin=${this.adminTools.length} tools.`,
+        )
       }
     } catch (err) {
       this.logger.error(`Failed to refresh MCP tools: ${err}`)
@@ -296,15 +306,16 @@ export class LlmService implements OnModuleInit {
           model: this.config.get<string>('appConfig.ollamaModel') ?? 'llama3',
         })
       case 'openai':
-      default:
-      {
+      default: {
         const maxTokens = this.config.get<number>('appConfig.openaiMaxTokens')
+        const baseUrl = this.config.get<string>('appConfig.openaiBaseUrl')
         return new ChatOpenAI({
           openAIApiKey: this.getOrThrow('OPENAI_API_KEY'),
           model: this.config.get<string>('appConfig.openaiModel') ?? 'gpt-4o',
           temperature: this.config.get<number>('appConfig.openaiTemperature'),
           maxTokens: -1,
           modelKwargs: maxTokens ? { max_completion_tokens: maxTokens } : undefined,
+          ...(baseUrl ? { configuration: { baseURL: baseUrl } } : {}),
         })
       }
     }
@@ -397,7 +408,10 @@ export class LlmService implements OnModuleInit {
    * Discovers tools from connected MCP servers and wraps each as a LangChain DynamicStructuredTool.
    * Returns both the full set (for admin) and the public-only set (for non-admin).
    */
-  private async buildMcpTools(): Promise<{ publicMcpTools: DynamicStructuredTool[]; allMcpTools: DynamicStructuredTool[] }> {
+  private async buildMcpTools(): Promise<{
+    publicMcpTools: DynamicStructuredTool[]
+    allMcpTools: DynamicStructuredTool[]
+  }> {
     const allInfos = await this.mcpService.listTools(true) // get ALL tools with isPublic metadata
     if (allInfos.length === 0) return { publicMcpTools: [], allMcpTools: [] }
 
@@ -415,17 +429,25 @@ export class LlmService implements OnModuleInit {
             const ctx = this.toolCallInterceptor.getCurrentContext()
             if (ctx && this.rbacService.isRbacActive()) {
               const interceptResult = await this.toolCallInterceptor.execute(
-                info.serverName, info.name, args, ctx, info.description,
+                info.serverName,
+                info.name,
+                args,
+                ctx,
+                info.description,
               )
               switch (interceptResult.type) {
                 case 'result':
-                  this.logger.log(`[MCP Tool:${info.serverName}/${info.name}] Result: ${interceptResult.data.slice(0, 300)}`)
+                  this.logger.log(
+                    `[MCP Tool:${info.serverName}/${info.name}] Result: ${interceptResult.data.slice(0, 300)}`,
+                  )
                   return interceptResult.data
                 case 'denied':
                   this.logger.warn(`[MCP Tool:${info.serverName}/${info.name}] DENIED: ${interceptResult.message}`)
                   return interceptResult.message
                 case 'pending_approval':
-                  this.logger.log(`[MCP Tool:${info.serverName}/${info.name}] PENDING APPROVAL: ${interceptResult.requestId}`)
+                  this.logger.log(
+                    `[MCP Tool:${info.serverName}/${info.name}] PENDING APPROVAL: ${interceptResult.requestId}`,
+                  )
                   return interceptResult.message
               }
             }
@@ -450,7 +472,9 @@ export class LlmService implements OnModuleInit {
     }
 
     const allMcpTools = allInfos.map((i) => this.mcpToolMap.get(`${i.serverName}/${i.name}`)!)
-    const publicMcpTools = allInfos.filter((i) => i.isPublic).map((i) => this.mcpToolMap.get(`${i.serverName}/${i.name}`)!)
+    const publicMcpTools = allInfos
+      .filter((i) => i.isPublic)
+      .map((i) => this.mcpToolMap.get(`${i.serverName}/${i.name}`)!)
 
     return { publicMcpTools, allMcpTools }
   }
@@ -461,7 +485,10 @@ export class LlmService implements OnModuleInit {
    * Falls back to a single { input: z.string() } if the schema is empty or unparseable.
    */
   private jsonSchemaToZod(schema: Record<string, unknown>): zod.ZodTypeAny {
-    const properties = (schema.properties ?? {}) as Record<string, { type?: string; description?: string; items?: { type?: string } }>
+    const properties = (schema.properties ?? {}) as Record<
+      string,
+      { type?: string; description?: string; items?: { type?: string } }
+    >
     const required = (schema.required ?? []) as string[]
 
     if (Object.keys(properties).length === 0) {
@@ -567,13 +594,14 @@ export class LlmService implements OnModuleInit {
     })
 
     const adminTools = adminToolsOverride ?? publicTools
-    const adminAgent = adminTools === publicTools
-      ? publicAgent
-      : createToolCallingAgent({
-          llm: this.llm as ChatOpenAI | ChatAnthropic,
-          tools: adminTools,
-          prompt,
-        })
+    const adminAgent =
+      adminTools === publicTools
+        ? publicAgent
+        : createToolCallingAgent({
+            llm: this.llm as ChatOpenAI | ChatAnthropic,
+            tools: adminTools,
+            prompt,
+          })
 
     return { publicAgent, adminAgent }
   }


### PR DESCRIPTION
- Add baseUrl field to llm Zod schema in agent-pack.loader.ts
- Add openaiBaseUrl config in app.config.ts (env: OPENAI_BASE_URL)
- Pass configuration.baseURL to ChatOpenAI when set in llm.service.ts
- Update README: mention compatible providers in overview, add env var
- Update agent-pack-schema: add baseUrl field, provider examples for Kimi, DeepSeek, Groq, and Together AI