### PR TITLE
feat: send invitation when user lacks required credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ docker compose -f docker/docker-compose.yml up -d
 This starts:
 - **Redis** on port 6379 (vector store + memory)
 - **PostgreSQL** on port 5432 (sessions, MCP user config)
-- **VS Agent** on ports 3002 (admin) / 3003 (public)
 
 ### Step 4: Run the full setup (optional, for VS Agent + credentials)
 

--- a/agent-packs/github-agent/agent-pack.yaml
+++ b/agent-packs/github-agent/agent-pack.yaml
@@ -132,6 +132,7 @@ flows:
   authentication:
     enabled: true
     credentialDefinitionId: ${CREDENTIAL_DEFINITION_ID}
+    issuerServiceDid: ${ISSUER_SERVICE_DID}
     adminAvatars:
       - mj
       - "@fafa"

--- a/agent-packs/github-agent/agent-pack.yaml
+++ b/agent-packs/github-agent/agent-pack.yaml
@@ -202,6 +202,13 @@ mcp:
           - get_file_contents
           - get_me
 
+speechToText:
+  requireAuth: false
+  provider:
+    name: whisper
+    type: openai-whisper
+    model: whisper-1
+
 integrations:
   vsAgent:
     adminUrl: ${VS_AGENT_ADMIN_URL}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,35 +2,16 @@
 # Hologram AI Agent MCP VS — Local Docker Compose
 # =============================================================================
 #
-# Runs ONLY dependent infrastructure services.
+# Runs ONLY dependent infrastructure services (Redis, PostgreSQL).
+# The VS Agent is deployed separately by scripts/setup.sh (with ngrok).
 # The chatbot itself runs natively via scripts/start.sh (for hot-reload).
 #
-# Prerequisites:
-#   - Docker and Docker Compose installed
-#   - ngrok running on port 3003 (or setup.sh handles this)
-#
 # Usage:
-#   source config.env
-#   export NGROK_DOMAIN=your-domain.ngrok-free.app
-#   docker compose up
+#   docker compose -f docker/docker-compose.yml up -d
 #
 # =============================================================================
 
 services:
-  vs-agent:
-    image: ${VS_AGENT_IMAGE:-veranalabs/vs-agent:latest}
-    platform: linux/amd64
-    ports:
-      - "${VS_AGENT_ADMIN_PORT:-3002}:3000"
-      - "${VS_AGENT_PUBLIC_PORT:-3003}:3001"
-    environment:
-      - AGENT_PUBLIC_DID=did:webvh:${NGROK_DOMAIN}
-      - AGENT_LABEL=${SERVICE_NAME:-Hologram AI Agent}
-      - ENABLE_PUBLIC_API_SWAGGER=true
-      - EVENTS_BASE_URL=http://host.docker.internal:${CHATBOT_PORT:-3010}
-    volumes:
-      - vs-agent-data:/root/.afj
-
   redis:
     image: redis/redis-stack-server:latest
     ports:
@@ -50,6 +31,5 @@ services:
       - postgres-data:/var/lib/postgresql/data
 
 volumes:
-  vs-agent-data:
   redis-data:
   postgres-data:

--- a/docs/agent-pack-schema.md
+++ b/docs/agent-pack-schema.md
@@ -31,6 +31,7 @@ The service reads the path provided via `AGENT_PACK_PATH`. If not set, it defaul
 | `flows`        | object | no       | Welcome, authentication, and menu behavior.                 |
 | `tools`        | object | no       | Dynamic tool JSON and bundled tool settings.                |
 | `mcp`          | object | no       | MCP (Model Context Protocol) server connections.            |
+| `speechToText` | object | no       | Speech-to-text (voice note transcription) configuration.    |
 | `integrations` | object | no       | External service configuration (VS Agent, DB, etc.).        |
 
 All top-level fields are optional.
@@ -469,6 +470,72 @@ mcp:
       toolAccess:
         default: public
 ```
+
+---
+
+### speechToText
+
+Configures voice note transcription (speech-to-text). When enabled, incoming audio `MediaMessage` items are transcribed and fed to the LLM as text input.
+
+| Field         | Type           | Default | Description                                                             |
+| ------------- | -------------- | ------- | ----------------------------------------------------------------------- |
+| `requireAuth` | boolean/string | `false` | When `true`, voice notes from unauthenticated users are rejected.       |
+| `provider`    | object         | —       | STT provider configuration (see below). If omitted, STT is disabled.   |
+
+#### speechToText.provider
+
+| Field       | Type   | Default        | Description                                                                                    |
+| ----------- | ------ | -------------- | ---------------------------------------------------------------------------------------------- |
+| `name`      | string | —              | Unique provider name (for logging).                                                            |
+| `type`      | string | —              | Provider type: `openai-whisper` (OpenAI cloud) or `whisper-compatible` (self-hosted endpoint). |
+| `model`     | string | `whisper-1`    | Whisper model name. Use `whisper-1` for OpenAI, or e.g. `large-v3` for self-hosted.           |
+| `apiKeyEnv` | string | `OPENAI_API_KEY` | Environment variable name containing the API key.                                            |
+| `baseUrl`   | string | —              | Base URL for self-hosted Whisper-compatible endpoints (e.g. `https://my-whisper.example.com/v1`). |
+| `language`  | string | —              | Optional language hint (ISO 639-1 code, e.g. `en`, `es`).                                     |
+
+Both `openai-whisper` and `whisper-compatible` use the same OpenAI-compatible `/v1/audio/transcriptions` API. The difference is that `whisper-compatible` is intended for self-hosted endpoints where `baseUrl` is required and `apiKeyEnv` may not be needed.
+
+```yaml
+# Example: OpenAI cloud Whisper
+speechToText:
+  requireAuth: true
+  provider:
+    name: whisper
+    type: openai-whisper
+    model: whisper-1
+    # apiKeyEnv: OPENAI_API_KEY  # default
+
+# Example: Self-hosted Whisper-compatible endpoint
+speechToText:
+  requireAuth: false
+  provider:
+    name: local-whisper
+    type: whisper-compatible
+    model: large-v3
+    baseUrl: https://my-whisper.example.com/v1
+```
+
+#### Voice authentication message
+
+When `requireAuth: true` and an unauthenticated user sends a voice note, the agent sends a `VOICE_AUTH_REQUIRED` message. This message is configurable per language via the `strings` map:
+
+```yaml
+languages:
+  en:
+    strings:
+      VOICE_AUTH_REQUIRED: "Please log in before sending voice messages."
+  es:
+    strings:
+      VOICE_AUTH_REQUIRED: "Inicia sesión antes de enviar mensajes de voz."
+```
+
+If not overridden, the following defaults are used:
+
+| Language | Default message |
+| -------- | --------------- |
+| `en`     | Voice messages require authentication. Please authenticate first to use this feature. |
+| `es`     | Los mensajes de voz requieren autenticación. Por favor, autentícate primero para usar esta función. |
+| `fr`     | Les messages vocaux nécessitent une authentification. Veuillez vous authentifier d'abord pour utiliser cette fonctionnalité. |
 
 ---
 

--- a/docs/agent-pack-schema.md
+++ b/docs/agent-pack-schema.md
@@ -211,6 +211,7 @@ memory:
 | `enabled`                | boolean/string | —                           | Enable credential-based authentication.                                     |
 | `required`               | boolean/string | `AUTH_REQUIRED`             | Block guest (unauthenticated) users from chatting.                          |
 | `credentialDefinitionId` | string         | `CREDENTIAL_DEFINITION_ID`  | Verifiable credential definition ID for authentication.                     |
+| `issuerServiceDid`       | string         | `ISSUER_SERVICE_DID`        | DID of the service that issues the required credential. When set, users who lack the credential receive an invitation to this service. |
 | `userIdentityAttribute`  | string         | `USER_IDENTITY_ATTRIBUTE`   | Credential attribute used as unique user identity (e.g., `email`, `login`). Default: `name`. |
 | `rolesAttribute`         | string         | `ROLES_ATTRIBUTE`           | Credential attribute containing user roles (string, CSV, or JSON array).    |
 | `defaultRole`            | string         | `DEFAULT_ROLE`              | Fallback role when credential lacks the roles attribute. Default: `user`.   |
@@ -244,6 +245,7 @@ flows:
     enabled: true
     required: true
     credentialDefinitionId: ${CREDENTIAL_DEFINITION_ID}
+    issuerServiceDid: ${ISSUER_SERVICE_DID}
     userIdentityAttribute: employeeLogin
     rolesAttribute: roles
     defaultRole: employee

--- a/src/config/agent-pack.loader.ts
+++ b/src/config/agent-pack.loader.ts
@@ -174,6 +174,21 @@ const AgentPackSchema = z
           .optional(),
       })
       .optional(),
+    speechToText: z
+      .object({
+        requireAuth: z.union([z.boolean(), z.string()]).optional(),
+        provider: z
+          .object({
+            name: z.string(),
+            type: z.string(),
+            model: z.string().optional(),
+            apiKeyEnv: z.string().optional(),
+            baseUrl: z.string().optional(),
+            language: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional(),
     integrations: z
       .object({
         vsAgent: z.any().optional(),

--- a/src/config/agent-pack.loader.ts
+++ b/src/config/agent-pack.loader.ts
@@ -83,6 +83,7 @@ const AgentPackSchema = z
             enabled: z.union([z.boolean(), z.string()]).optional(),
             required: z.union([z.boolean(), z.string()]).optional(),
             credentialDefinitionId: z.string().optional(),
+            issuerServiceDid: z.string().optional(),
             userIdentityAttribute: z.string().optional(),
             rolesAttribute: z.string().optional(),
             defaultRole: z.string().optional(),
@@ -452,6 +453,8 @@ export interface AuthFlowConfig {
   /** When true, unauthenticated users cannot send messages */
   required: boolean
   credentialDefinitionId?: string
+  /** DID of the service that issues the required credential (used to send invitation on no-compatible-credentials) */
+  issuerServiceDid?: string
   /** Credential attribute that uniquely identifies the user (e.g., 'name', 'email') */
   userIdentityAttribute: string
   /** Credential attribute containing the user's role(s) */

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -306,4 +306,18 @@ export default registerAs('appConfig', () => ({
    * Configurable via MCP_SERVERS_CONFIG env var (JSON array) or agent-pack mcp.servers.
    */
   mcpServers: resolveMcpServers(process.env.MCP_SERVERS_CONFIG, agentPack?.mcp?.servers),
+
+  // Speech-to-Text Configuration
+  sttProvider: agentPack?.speechToText?.provider
+    ? (agentPack.speechToText.provider as {
+        name: string
+        type: string
+        model?: string
+        apiKeyEnv?: string
+        baseUrl?: string
+        language?: string
+      })
+    : undefined,
+  sttRequireAuth: agentPack?.speechToText?.requireAuth === true
+    || agentPack?.speechToText?.requireAuth === 'true',
 }))

--- a/src/core/agent-content.service.ts
+++ b/src/core/agent-content.service.ts
@@ -132,6 +132,7 @@ export class AgentContentService {
       enabled: this.toBoolean(authConfig.enabled, true),
       required: this.configService.get<boolean>('appConfig.authRequired') ?? false,
       credentialDefinitionId,
+      issuerServiceDid: authConfig.issuerServiceDid,
       userIdentityAttribute: this.configService.get<string>('appConfig.userIdentityAttribute') ?? 'name',
       rolesAttribute: this.configService.get<string>('appConfig.rolesAttribute') || undefined,
       defaultRole: this.configService.get<string>('appConfig.defaultRole') ?? 'user',

--- a/src/core/common/i18n/i18n.ts
+++ b/src/core/common/i18n/i18n.ts
@@ -28,6 +28,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
     PENDING_APPROVALS: 'Pending approvals',
     PENDING_APPROVALS_PROMPT: 'Pending approval requests you can act on. Select one to approve or reject:',
     NO_PENDING_APPROVALS: 'There are no pending approvals for you to review.',
+    VOICE_AUTH_REQUIRED: 'Voice messages require authentication. Please authenticate first to use this feature.',
   },
   es: {
     ROOT_TITLE: '¡Bienvenido!',
@@ -55,6 +56,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
     PENDING_APPROVALS: 'Aprobaciones pendientes',
     PENDING_APPROVALS_PROMPT: 'Solicitudes de aprobación pendientes que puedes revisar. Selecciona una para aprobar o rechazar:',
     NO_PENDING_APPROVALS: 'No hay aprobaciones pendientes para ti.',
+    VOICE_AUTH_REQUIRED: 'Los mensajes de voz requieren autenticación. Por favor, autentícate primero para usar esta función.',
   },
   fr: {
     ROOT_TITLE: 'Bienvenue !',
@@ -82,6 +84,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
     PENDING_APPROVALS: 'Approbations en attente',
     PENDING_APPROVALS_PROMPT: "Demandes d'approbation en attente que vous pouvez traiter. Sélectionnez-en une pour approuver ou rejeter :",
     NO_PENDING_APPROVALS: "Il n'y a pas d'approbations en attente pour vous.",
+    VOICE_AUTH_REQUIRED: "Les messages vocaux nécessitent une authentification. Veuillez vous authentifier d'abord pour utiliser cette fonctionnalité.",
   },
 }
 

--- a/src/core/common/i18n/i18n.ts
+++ b/src/core/common/i18n/i18n.ts
@@ -29,6 +29,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
     PENDING_APPROVALS_PROMPT: 'Pending approval requests you can act on. Select one to approve or reject:',
     NO_PENDING_APPROVALS: 'There are no pending approvals for you to review.',
     VOICE_AUTH_REQUIRED: 'Voice messages require authentication. Please authenticate first to use this feature.',
+    AUTH_NO_CREDENTIAL: 'You don\'t have the required credential yet. Here is an invitation to the service that can issue it:',
   },
   es: {
     ROOT_TITLE: '¡Bienvenido!',
@@ -57,6 +58,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
     PENDING_APPROVALS_PROMPT: 'Solicitudes de aprobación pendientes que puedes revisar. Selecciona una para aprobar o rechazar:',
     NO_PENDING_APPROVALS: 'No hay aprobaciones pendientes para ti.',
     VOICE_AUTH_REQUIRED: 'Los mensajes de voz requieren autenticación. Por favor, autentícate primero para usar esta función.',
+    AUTH_NO_CREDENTIAL: 'Aún no tienes la credencial requerida. Aquí tienes una invitación al servicio que puede emitirla:',
   },
   fr: {
     ROOT_TITLE: 'Bienvenue !',
@@ -85,6 +87,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
     PENDING_APPROVALS_PROMPT: "Demandes d'approbation en attente que vous pouvez traiter. Sélectionnez-en une pour approuver ou rejeter :",
     NO_PENDING_APPROVALS: "Il n'y a pas d'approbations en attente pour vous.",
     VOICE_AUTH_REQUIRED: "Les messages vocaux nécessitent une authentification. Veuillez vous authentifier d'abord pour utiliser cette fonctionnalité.",
+    AUTH_NO_CREDENTIAL: "Vous n'avez pas encore le justificatif requis. Voici une invitation au service qui peut vous le délivrer :",
   },
 }
 

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -6,6 +6,7 @@ import { ConnectionEntity, EventsModule } from '@2060.io/vs-agent-nestjs-client'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { ChatbotModule } from 'src/chatbot/chatbot.module'
 import { MemoryModule } from 'src/memory/memory.module'
+import { SttModule } from 'src/stt/stt.module'
 import { AgentContentService } from './agent-content.service'
 import { McpConfigEntity } from '../mcp/mcp-config.entity'
 import { ApprovalRequestEntity } from '../rbac/approval-request.entity'
@@ -34,6 +35,7 @@ import { ApprovalRequestEntity } from '../rbac/approval-request.entity'
     }),
     ChatbotModule,
     MemoryModule,
+    SttModule,
     EventsModule,
   ],
   controllers: [],

--- a/src/core/core.service.ts
+++ b/src/core/core.service.ts
@@ -148,7 +148,7 @@ export class CoreService implements EventHandler, OnModuleInit {
           if (audioItem && this.sttService.isEnabled) {
             if (!this.sttService.isAllowed(session.isAuthenticated ?? false)) {
               this.logger.log(`[STT] Blocked voice note from unauthenticated user ${session.connectionId}`)
-              await this.sendText(session.connectionId, this.getText('AUTH_REQUIRED', session.lang), session.lang)
+              await this.sendText(session.connectionId, this.getText('VOICE_AUTH_REQUIRED', session.lang), session.lang)
             } else {
               try {
                 const result = await this.sttService.transcribeFromUrl(audioItem.uri, audioItem.mimeType)

--- a/src/core/core.service.ts
+++ b/src/core/core.service.ts
@@ -35,6 +35,7 @@ import { McpService } from '../mcp/mcp.service'
 import { RbacService } from '../rbac/rbac.service'
 import { ApprovalService } from '../rbac/approval.service'
 import type { AuthFlowConfig } from '../config/agent-pack.loader'
+import { SttService } from '../stt/stt.service'
 
 @Injectable()
 export class CoreService implements EventHandler, OnModuleInit {
@@ -53,6 +54,7 @@ export class CoreService implements EventHandler, OnModuleInit {
     private readonly mcpService: McpService,
     @Optional() private readonly rbacService: RbacService,
     @Optional() private readonly approvalService: ApprovalService,
+    private readonly sttService: SttService,
   ) {
     const baseUrl = configService.get<string>('appConfig.vsAgentAdminUrl') || 'http://localhost:3001'
     this.apiClient = new ApiClient(baseUrl, ApiVersion.V1)
@@ -140,10 +142,29 @@ export class CoreService implements EventHandler, OnModuleInit {
           }
           break
         }
-        case MediaMessage.type:
-          //inMsg = JsonTransformer.fromJSON(message, MediaMessage)
-          content = 'media'
+        case MediaMessage.type: {
+          const mediaMsg = JsonTransformer.fromJSON(message, MediaMessage) as unknown as MediaMessage
+          const audioItem = mediaMsg.items?.find((item) => this.sttService.isAudioMimeType(item.mimeType))
+          if (audioItem && this.sttService.isEnabled) {
+            if (!this.sttService.isAllowed(session.isAuthenticated ?? false)) {
+              this.logger.log(`[STT] Blocked voice note from unauthenticated user ${session.connectionId}`)
+              await this.sendText(session.connectionId, this.getText('AUTH_REQUIRED', session.lang), session.lang)
+            } else {
+              try {
+                const result = await this.sttService.transcribeFromUrl(audioItem.uri, audioItem.mimeType)
+                if (result.text.trim().length > 0) {
+                  content = { content: result.text.trim() }
+                }
+              } catch (err) {
+                this.logger.error(`[STT] Transcription failed: ${err}`)
+                await this.sendText(session.connectionId, this.getText('ERROR_MESSAGES', session.lang), session.lang)
+              }
+            }
+          } else {
+            content = 'media'
+          }
           break
+        }
         case ProfileMessage.type: {
           const inMsg = JsonTransformer.fromJSON(message, ProfileMessage) as unknown as ProfileMessage
           if (inMsg.preferredLanguage) {

--- a/src/core/core.service.ts
+++ b/src/core/core.service.ts
@@ -151,7 +151,7 @@ export class CoreService implements EventHandler, OnModuleInit {
               await this.sendText(session.connectionId, this.getText('VOICE_AUTH_REQUIRED', session.lang), session.lang)
             } else {
               try {
-                const result = await this.sttService.transcribeFromUrl(audioItem.uri, audioItem.mimeType)
+                const result = await this.sttService.transcribeFromUrl(audioItem.uri, audioItem.mimeType, audioItem.ciphering)
                 if (result.text.trim().length > 0) {
                   content = { content: result.text.trim() }
                 }

--- a/src/core/core.service.ts
+++ b/src/core/core.service.ts
@@ -15,6 +15,7 @@ import {
   ProfileMessage,
   StatEnum,
   TextMessage,
+  InvitationMessage,
   VerifiableCredentialRequestedProofItem,
   VerifiableCredentialSubmittedProofItem,
 } from '@2060.io/vs-agent-nestjs-client'
@@ -425,11 +426,31 @@ export class CoreService implements EventHandler, OnModuleInit {
               await this.sendText(connectionId, message, userLang)
             } else if (proofItem?.errorCode) {
               this.logger.warn(`[AUTH] Proof submission failed with error: ${proofItem.errorCode}`)
-              await this.sendText(
-                connectionId,
-                `${this.getText('AUTH_ERROR', userLang)}: ${proofItem.errorCode}`,
-                userLang,
-              )
+
+              if (
+                proofItem.errorCode === 'e.req.no-compatible-credentials' &&
+                this.authFlowConfig.issuerServiceDid
+              ) {
+                await this.sendText(connectionId, this.getText('AUTH_NO_CREDENTIAL', userLang), userLang)
+                await this.apiClient.messages.send(
+                  new InvitationMessage({
+                    connectionId,
+                    did: this.authFlowConfig.issuerServiceDid,
+                  }),
+                )
+                this.logger.log(
+                  `[AUTH] Sent invitation to issuer service ${this.authFlowConfig.issuerServiceDid} for ${connectionId}`,
+                )
+              } else {
+                await this.sendText(
+                  connectionId,
+                  `${this.getText('AUTH_ERROR', userLang)}: ${proofItem.errorCode}`,
+                  userLang,
+                )
+              }
+
+              session.state = StateStep.CHAT
+              await this.sessionRepository.save(session)
             } else {
               await this.sendText(connectionId, this.getText('WAITING_CREDENTIAL', userLang), userLang)
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,17 @@ async function bootstrap() {
   const appName = packageJson.name
   const appVersion = packageJson.version
 
+  // Log agent-pack info
+  const packMeta = configService.get('appConfig.agentPackMeta')
+  if (packMeta?.manifestPath) {
+    logger.log(`Agent pack loaded: ${packMeta.manifestPath}`)
+  } else {
+    logger.warn(`No agent pack loaded. Warnings: ${packMeta?.warnings?.join('; ') ?? 'none'}`)
+  }
+  if (packMeta?.warnings?.length) {
+    packMeta.warnings.forEach((w: string) => logger.warn(`Agent pack warning: ${w}`))
+  }
+
   // Log the URL where the application is running
   logger.log(`Application (${appName} v${appVersion}) running on: ${await app.getUrl()} `)
 }

--- a/src/stt/providers/openai-whisper.provider.ts
+++ b/src/stt/providers/openai-whisper.provider.ts
@@ -1,0 +1,77 @@
+import OpenAI from 'openai'
+import { Uploadable } from 'openai/uploads'
+import type { SttProvider, SttProviderConfig, TranscriptionResult } from './stt-provider.interface'
+
+/**
+ * Mime-type to file extension mapping for audio formats supported by Whisper.
+ */
+const MIME_TO_EXT: Record<string, string> = {
+  'audio/flac': 'flac',
+  'audio/mp3': 'mp3',
+  'audio/mpeg': 'mp3',
+  'audio/mp4': 'mp4',
+  'audio/m4a': 'm4a',
+  'audio/x-m4a': 'm4a',
+  'audio/ogg': 'ogg',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/webm': 'webm',
+  'audio/aac': 'aac',
+}
+
+/**
+ * Provider for OpenAI Whisper API and any Whisper-compatible self-hosted endpoint.
+ * Both expose the same `/v1/audio/transcriptions` endpoint.
+ */
+export class OpenAiWhisperProvider implements SttProvider {
+  readonly name: string
+  private readonly client: OpenAI
+  private readonly model: string
+  private readonly language?: string
+
+  constructor(config: SttProviderConfig) {
+    this.name = config.name
+    this.model = config.model ?? 'whisper-1'
+    this.language = config.language || undefined
+
+    const apiKey = config.apiKeyEnv
+      ? process.env[config.apiKeyEnv]
+      : process.env.OPENAI_API_KEY
+
+    if (!apiKey && !config.baseUrl) {
+      throw new Error(
+        `OpenAiWhisperProvider "${config.name}": missing API key. ` +
+        `Set ${config.apiKeyEnv ?? 'OPENAI_API_KEY'} in the environment.`,
+      )
+    }
+
+    this.client = new OpenAI({
+      apiKey: apiKey || 'not-needed',
+      ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+    })
+  }
+
+  async transcribe(audioBuffer: Buffer, mimeType: string): Promise<TranscriptionResult> {
+    const ext = MIME_TO_EXT[mimeType] ?? 'ogg'
+    const fileName = `audio.${ext}`
+
+    const file: Uploadable = new File(
+      [new Uint8Array(audioBuffer)],
+      fileName,
+      { type: mimeType },
+    )
+
+    const response = await this.client.audio.transcriptions.create({
+      model: this.model,
+      file,
+      ...(this.language ? { language: this.language } : {}),
+      response_format: 'verbose_json',
+    })
+
+    return {
+      text: response.text,
+      language: (response as any).language ?? undefined,
+      duration: (response as any).duration ?? undefined,
+    }
+  }
+}

--- a/src/stt/providers/stt-provider.factory.ts
+++ b/src/stt/providers/stt-provider.factory.ts
@@ -1,0 +1,16 @@
+import type { SttProvider, SttProviderConfig } from './stt-provider.interface'
+import { OpenAiWhisperProvider } from './openai-whisper.provider'
+
+/**
+ * Creates an SttProvider instance based on the provider type in the config.
+ * Add new providers here as they are implemented.
+ */
+export function createSttProvider(config: SttProviderConfig): SttProvider {
+  switch (config.type) {
+    case 'openai-whisper':
+    case 'whisper-compatible':
+      return new OpenAiWhisperProvider(config)
+    default:
+      throw new Error(`Unknown speech-to-text provider type: "${config.type}"`)
+  }
+}

--- a/src/stt/providers/stt-provider.interface.ts
+++ b/src/stt/providers/stt-provider.interface.ts
@@ -1,0 +1,34 @@
+/**
+ * Result returned by a speech-to-text provider.
+ */
+export interface TranscriptionResult {
+  text: string
+  language?: string
+  duration?: number
+}
+
+/**
+ * Provider-specific configuration loaded from agent-pack.yaml.
+ */
+export interface SttProviderConfig {
+  /** Unique name used to reference this provider. */
+  name: string
+  /** Provider type identifier (e.g. "openai-whisper", "whisper-compatible"). */
+  type: string
+  /** Model name (e.g. "whisper-1", "large-v3"). */
+  model?: string
+  /** Environment variable name holding the API key. */
+  apiKeyEnv?: string
+  /** Base URL for the API. Empty = OpenAI cloud. Set for self-hosted. */
+  baseUrl?: string
+  /** Optional language hint (ISO 639-1, e.g. "en", "es"). */
+  language?: string
+}
+
+/**
+ * All speech-to-text providers must implement this interface.
+ */
+export interface SttProvider {
+  readonly name: string
+  transcribe(audioBuffer: Buffer, mimeType: string): Promise<TranscriptionResult>
+}

--- a/src/stt/stt.module.ts
+++ b/src/stt/stt.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { SttService } from './stt.service'
+
+@Module({
+  providers: [SttService],
+  exports: [SttService],
+})
+export class SttModule {}

--- a/src/stt/stt.module.ts
+++ b/src/stt/stt.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common'
+import { Global, Module } from '@nestjs/common'
 import { SttService } from './stt.service'
 
+@Global()
 @Module({
   providers: [SttService],
   exports: [SttService],

--- a/src/stt/stt.service.ts
+++ b/src/stt/stt.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import type { SttProvider, SttProviderConfig, TranscriptionResult } from './providers/stt-provider.interface'
+import { createSttProvider } from './providers/stt-provider.factory'
+
+const AUDIO_MIME_PREFIXES = ['audio/']
+
+@Injectable()
+export class SttService implements OnModuleInit {
+  private readonly logger = new Logger(SttService.name)
+  private provider: SttProvider | null = null
+  private requireAuth = false
+
+  constructor(private readonly config: ConfigService) {}
+
+  async onModuleInit() {
+    const providerConfig = this.config.get<SttProviderConfig>('appConfig.sttProvider')
+    this.requireAuth = this.config.get<boolean>('appConfig.sttRequireAuth') ?? false
+
+    if (!providerConfig) {
+      this.logger.log('No speech-to-text provider configured. Voice notes will not be transcribed.')
+      return
+    }
+
+    try {
+      this.provider = createSttProvider(providerConfig)
+      this.logger.log(
+        `STT provider "${providerConfig.name}" (${providerConfig.type}) initialized. ` +
+        `requireAuth=${this.requireAuth}`,
+      )
+    } catch (err) {
+      this.logger.error(`Failed to initialize STT provider "${providerConfig.name}": ${err}`)
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.provider !== null
+  }
+
+  /**
+   * Returns true if the given MIME type is an audio format that can be transcribed.
+   */
+  isAudioMimeType(mimeType: string): boolean {
+    return AUDIO_MIME_PREFIXES.some((prefix) => mimeType.toLowerCase().startsWith(prefix))
+  }
+
+  /**
+   * Check whether transcription is allowed for the given session.
+   * Returns false if requireAuth is true and the user is not authenticated.
+   */
+  isAllowed(isAuthenticated: boolean): boolean {
+    if (!this.isEnabled) return false
+    if (this.requireAuth && !isAuthenticated) return false
+    return true
+  }
+
+  /**
+   * Download audio from a URL and transcribe it.
+   */
+  async transcribeFromUrl(url: string, mimeType: string): Promise<TranscriptionResult> {
+    if (!this.provider) {
+      throw new Error('STT provider is not configured.')
+    }
+
+    this.logger.log(`Downloading audio from URL for transcription (${mimeType})...`)
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to download audio from ${url}: ${response.status}`)
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    this.logger.log(`Downloaded ${Math.round(buffer.length / 1024)}KB audio. Transcribing...`)
+
+    const result = await this.provider.transcribe(buffer, mimeType)
+
+    this.logger.log(
+      `Transcription complete: "${result.text.slice(0, 100)}${result.text.length > 100 ? '...' : ''}" ` +
+      `(lang=${result.language ?? 'unknown'}, duration=${result.duration ?? '?'}s)`,
+    )
+
+    return result
+  }
+}

--- a/src/stt/stt.service.ts
+++ b/src/stt/stt.service.ts
@@ -1,7 +1,13 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { createDecipheriv } from 'crypto'
 import type { SttProvider, SttProviderConfig, TranscriptionResult } from './providers/stt-provider.interface'
 import { createSttProvider } from './providers/stt-provider.factory'
+
+export interface AudioCiphering {
+  algorithm: string
+  parameters?: Record<string, unknown>
+}
 
 const AUDIO_MIME_PREFIXES = ['audio/']
 
@@ -57,7 +63,7 @@ export class SttService implements OnModuleInit {
   /**
    * Download audio from a URL and transcribe it.
    */
-  async transcribeFromUrl(url: string, mimeType: string): Promise<TranscriptionResult> {
+  async transcribeFromUrl(url: string, mimeType: string, ciphering?: AudioCiphering): Promise<TranscriptionResult> {
     if (!this.provider) {
       throw new Error('STT provider is not configured.')
     }
@@ -70,7 +76,12 @@ export class SttService implements OnModuleInit {
     }
 
     const arrayBuffer = await response.arrayBuffer()
-    const buffer = Buffer.from(arrayBuffer)
+    let buffer: Buffer = Buffer.from(new Uint8Array(arrayBuffer))
+
+    if (ciphering) {
+      buffer = this.decrypt(buffer, ciphering)
+      this.logger.log(`Decrypted audio (${ciphering.algorithm}): ${Math.round(buffer.length / 1024)}KB`)
+    }
 
     this.logger.log(`Downloaded ${Math.round(buffer.length / 1024)}KB audio. Transcribing...`)
 
@@ -82,5 +93,21 @@ export class SttService implements OnModuleInit {
     )
 
     return result
+  }
+
+  private decrypt(encrypted: Buffer, ciphering: AudioCiphering): Buffer {
+    const key = ciphering.parameters?.['key'] as string | undefined
+    const iv = ciphering.parameters?.['iv'] as string | undefined
+
+    if (!key || !iv) {
+      throw new Error(`Missing key or iv in ciphering parameters`)
+    }
+
+    const decipher = createDecipheriv(
+      ciphering.algorithm,
+      Buffer.from(key, 'hex'),
+      Buffer.from(iv, 'hex'),
+    )
+    return Buffer.from(Buffer.concat([decipher.update(encrypted), decipher.final()]))
   }
 }


### PR DESCRIPTION
## Summary

When a user attempts to authenticate but does not possess the required verifiable credential (`e.req.no-compatible-credentials`), the agent now automatically sends an `InvitationMessage` pointing to the issuer service so the user can obtain the credential.

## Changes

- **Handle `e.req.no-compatible-credentials`** in `core.service.ts` — sends a localized text message followed by an `InvitationMessage` with the configured issuer service DID
- **Fix stuck sessions** — reset `session.state` back to `CHAT` on any auth error (previously the session remained in `AUTH` indefinitely)
- **New config: `issuerServiceDid`** — added to Zod schema, `AuthFlowConfig` interface, config resolver, `agent-pack.yaml`, and `.env`
- **i18n** — added `AUTH_NO_CREDENTIAL` key in en/es/fr
- **Docs** — updated `agent-pack-schema.md` with `issuerServiceDid` field documentation