### PR TITLE
fix: add helm dependency build before packaging in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -97,6 +97,9 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_LOGIN }}
           password: ${{ secrets.DOCKER_HUB_PWD }}
 
+      - name: Build Helm dependencies
+        run: helm dependency build ./charts
+
       - name: Push Helm chart to Docker Hub OCI repo
         run: |
           if [ "$RELEASE_TYPE" = "stable" ]; then


### PR DESCRIPTION
## Problem

`helm package` fails with:
```
Error: found in Chart.yaml, but missing in charts/ directory: vs-agent-chart
```

The `vs-agent-chart` dependency is declared in `charts/Chart.yaml` but `helm dependency build` was never run before `helm package`, so the dependency tarball is missing from the `charts/` directory.

## Fix

Added a `helm dependency build ./charts` step before the packaging/push step in the CD workflow. This fetches the `vs-agent-chart` dependency from the OCI registry before packaging.