### PR TITLE
feat: improve agent memory context for voice notes, media, and generated content

### DIFF
--- a/src/core/core.service.ts
+++ b/src/core/core.service.ts
@@ -158,7 +158,11 @@ export class CoreService implements EventHandler, OnModuleInit {
                   audioItem.ciphering,
                 )
                 if (result.text.trim().length > 0) {
-                  content = { content: result.text.trim() }
+                  content = new TextMessage({
+                    connectionId: message.connectionId,
+                    content: `[Voice note] ${result.text.trim()}`,
+                    ...(message.threadId ? { threadId: message.threadId } : {}),
+                  })
                 }
               } catch (err) {
                 this.logger.error(`[STT] Transcription failed: ${err}`)
@@ -166,7 +170,14 @@ export class CoreService implements EventHandler, OnModuleInit {
               }
             }
           } else {
-            content = 'media'
+            // Non-audio media: describe items so LLM has context
+            const items = mediaMsg.items ?? []
+            const desc = items.map((it) => it.mimeType).join(', ')
+            content = new TextMessage({
+              connectionId: message.connectionId,
+              content: `[Media received: ${desc || 'unknown'}]`,
+              ...(message.threadId ? { threadId: message.threadId } : {}),
+            })
           }
           break
         }
@@ -361,16 +372,18 @@ export class CoreService implements EventHandler, OnModuleInit {
             'content' in content &&
             typeof (content as Record<string, unknown>).content === 'string'
           ) {
-            const textContent = (content as { content: string }).content.trim()
+            const rawText = (content as { content: string }).content.trim()
+            const threadId = (content as any).threadId as string | undefined
+            const textContent = threadId ? `[Replying to messageId: ${threadId}] ${rawText}` : rawText
 
             // Guest access check: when auth is required, block unauthenticated messages
-            if (textContent.length > 0 && !session.isAuthenticated && this.authFlowConfig.required) {
+            if (rawText.length > 0 && !session.isAuthenticated && this.authFlowConfig.required) {
               this.logger.log(`[GUEST] Blocked message from unauthenticated user ${connectionId}`)
               await this.sendText(connectionId, this.getText('AUTH_REQUIRED', userLang), userLang)
               break
             }
 
-            if (textContent.length > 0) {
+            if (rawText.length > 0) {
               const answer = await this.chatBotService.chat({
                 userInput: textContent,
                 session,

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -240,6 +240,7 @@ export class LlmService implements OnModuleInit {
           tools,
           memory,
           verbose: this.config.get<boolean>('appConfig.agentVerbose') ?? false,
+          returnIntermediateSteps: true,
         }) as any as AgentExecutor
 
         // Build RBAC user context for ToolCallInterceptor

--- a/src/media/image-generation.service.ts
+++ b/src/media/image-generation.service.ts
@@ -24,6 +24,7 @@ export interface GenerateImageRequest {
 export interface GeneratedImageResult {
   refId: string
   previewUrl: string
+  ciphering: CipheringInfo
 }
 
 @Injectable()
@@ -77,7 +78,7 @@ export class ImageGenerationService implements OnModuleInit {
   /**
    * Generate images, convert to target specs, upload to MinIO, and return refs.
    */
-  async generate(request: GenerateImageRequest): Promise<GeneratedImageResult[]> {
+  async generate(request: GenerateImageRequest): Promise<{ images: GeneratedImageResult[]; sentMessageId?: string }> {
     const provider = this.providers.get(request.provider)
     if (!provider) {
       throw new Error(
@@ -131,7 +132,7 @@ export class ImageGenerationService implements OnModuleInit {
       // Step 5: Store ref for later retrieval by bridge tool
       const refId = this.refStore.add(converted.buffer, converted.mimeType, previewUrl)
 
-      results.push({ refId, previewUrl })
+      results.push({ refId, previewUrl, ciphering })
       eventImages.push({
         url: previewUrl,
         mimeType: converted.mimeType,
@@ -145,6 +146,7 @@ export class ImageGenerationService implements OnModuleInit {
     this.logger.log(`Generated and stored ${results.length} image(s): ${results.map((r) => r.refId).join(', ')}`)
 
     // Send MediaMessage directly to the user (avoids event triple-fire)
+    let sentMessageId: string | undefined
     const ctx = this.callerCtx.getStore()
     if (ctx?.connectionId) {
       try {
@@ -160,13 +162,14 @@ export class ImageGenerationService implements OnModuleInit {
               ...(img.ciphering ? { ciphering: img.ciphering } : {}),
             }),
         )
-        await this.apiClient.messages.send(
+        const sent = await this.apiClient.messages.send(
           new MediaMessage({
             connectionId: ctx.connectionId,
             items,
           }),
         )
-        this.logger.log(`Sent MediaMessage to ${ctx.connectionId}: ${items.length} item(s)`)
+        sentMessageId = sent?.id
+        this.logger.log(`Sent MediaMessage ${sentMessageId} to ${ctx.connectionId}: ${items.length} item(s)`)
       } catch (err) {
         this.logger.error(`Failed to send MediaMessage: ${err}`)
       }
@@ -174,7 +177,7 @@ export class ImageGenerationService implements OnModuleInit {
       this.logger.warn('No connectionId in caller context — MediaMessage will not be sent to user.')
     }
 
-    return results
+    return { images: results, sentMessageId }
   }
 
   /**

--- a/src/media/tools/generate-image.tool.ts
+++ b/src/media/tools/generate-image.tool.ts
@@ -38,7 +38,7 @@ export function createGenerateImageTool(imageGenService: ImageGenerationService)
       try {
         logger.log(`generate_image called: provider=${args.provider}, prompt="${args.prompt}", n=${args.n ?? 1}`)
 
-        const results = await imageGenService.generate({
+        const { images, sentMessageId } = await imageGenService.generate({
           provider: args.provider,
           prompt: args.prompt,
           n: args.n,
@@ -51,11 +51,17 @@ export function createGenerateImageTool(imageGenService: ImageGenerationService)
 
         const response = {
           status: 'ok',
-          images: results.map((r) => ({
+          provider: args.provider,
+          prompt: args.prompt,
+          sentMessageId,
+          images: images.map((r) => ({
             refId: r.refId,
+            url: r.previewUrl,
+            ciphering: r.ciphering,
           })),
           message:
-            `Done. ${results.length} image(s) have already been delivered to the user — do NOT call generate_image again for this request. ` +
+            `Done. ${images.length} image(s) have already been delivered to the user (messageId: ${sentMessageId ?? 'unknown'}) — do NOT call generate_image again for this request. ` +
+            `If the user replies to the media message, their reply will include [Replying to messageId: ${sentMessageId}]. ` +
             `If the user wants to upload an image to an external service, use upload_media_to_mcp with the refId.`,
         }
 

--- a/src/memory/langchain-session-memory.ts
+++ b/src/memory/langchain-session-memory.ts
@@ -68,6 +68,24 @@ export class LangchainSessionMemory extends BaseChatMemory {
       await this.memoryService.addMessage(this.sessionId, 'user', userInput)
     }
 
+    // Persist intermediate tool steps so the LLM can reference them on subsequent turns
+    const steps = output.intermediateSteps as
+      | { action: { tool: string; toolInput: Record<string, unknown> }; observation: string }[]
+      | undefined
+    if (steps?.length) {
+      const summary = steps
+        .map((s) => {
+          const args = JSON.stringify(s.action.toolInput)
+          const obs = s.observation.length > 500 ? s.observation.slice(0, 500) + '…' : s.observation
+          return `${s.action.tool}(${args}) → ${obs}`
+        })
+        .join('\n')
+      this.logger.debug(
+        `[saveContext] -> addMessage(role=system, tool-steps) sessionId=${this.sessionId} steps=${steps.length}`,
+      )
+      await this.memoryService.addMessage(this.sessionId, 'system', `[Tool calls]\n${summary}`)
+    }
+
     if (aiOutput) {
       this.logger.debug(
         `[saveContext] -> addMessage(role=system) sessionId=${this.sessionId} content="${aiOutput.slice(0, 120)}${aiOutput.length > 120 ? '...' : ''}"`,


### PR DESCRIPTION
## Summary

Minimal, targeted improvements to agent memory persistence so the LLM retains useful context about tool usage, voice notes, media, and generated content across conversation turns.

### Changes

**`src/core/core.service.ts`**
- **Voice notes**: transcribed audio now prefixed with `[Voice note]` so the LLM knows the input came from audio
- **Non-audio media**: replaced generic `'media'` string with `[Media received: image/jpeg, ...]` describing the actual mime types
- **ThreadId correlation**: when incoming message has `threadId` (user replying to a specific outgoing message), prepends `[Replying to messageId: <id>]` so the LLM can correlate replies to generated content

**`src/media/image-generation.service.ts`**
- `GeneratedImageResult` now includes `ciphering` (AES key info)
- `generate()` returns `{ images, sentMessageId }` — captures the DIDComm messageId from `send()`

**`src/media/tools/generate-image.tool.ts`**
- Tool response now includes `provider`, `prompt`, `sentMessageId`, and per-image `url` + `ciphering`
- LLM is told how reply correlation works via the tool message

**`src/llm/llm.service.ts`**
- Enable `returnIntermediateSteps: true` on AgentExecutor so tool calls flow into saveContext

**`src/memory/langchain-session-memory.ts`**
- Persist intermediate tool steps as `[Tool calls]` system messages in session memory

### How it works

1. When the LLM calls `generate_image`, the full metadata (prompt, provider, URLs, AES keys, messageId) is returned and persisted in the `[Tool calls]` memory entry
2. When the user replies to a generated image, the incoming message carries `threadId` = the original `sentMessageId`
3. The LLM sees `[Replying to messageId: abc-123]` and can match it to its tool call history

### Testing
- `tsc --noEmit` ✅
- `jest` 5/5 ✅