### PR TITLE
feat(mcp): auto-reconnect shared MCP connections on failure

### DIFF
--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -134,28 +134,58 @@ export class McpService implements OnModuleInit, OnModuleDestroy {
     const allTools: McpToolInfo[] = []
     const discoveredServers = new Set<string>()
 
-    // Tools from shared (admin) connections
-    for (const conn of this.connections) {
+    // Consider all shared server defs (admin-controlled, or user-controlled with a shared admin connection).
+    // For each, try to use the live connection; if absent or errored, attempt a single reconnect.
+    for (const def of this.serverDefs) {
+      if (def.accessMode === 'user-controlled' && this.hasUnresolvedHeaders(def)) continue
+
+      let conn = this.connections.find((c) => c.name === def.name)
+      if (!conn) {
+        const ok = await this.reconnectShared(def.name)
+        if (!ok) continue
+        conn = this.connections.find((c) => c.name === def.name)
+        if (!conn) continue
+      }
+
       discoveredServers.add(conn.name)
       const access = this.toolAccessMap.get(conn.name)
-      try {
-        let cursor: string | undefined
-        do {
-          const result = await conn.client.listTools({ cursor })
-          for (const tool of result.tools) {
-            const pub = this.isToolPublic(tool.name, access)
-            allTools.push({
-              serverName: conn.name,
-              name: tool.name,
-              description: tool.description ?? '',
-              inputSchema: (tool.inputSchema as Record<string, unknown>) ?? {},
-              isPublic: pub,
-            })
-          }
-          cursor = result.nextCursor
-        } while (cursor)
-      } catch (err) {
-        this.logger.error(`Error listing tools from MCP server "${conn.name}": ${err}`)
+
+      const fetchOnce = async (c: McpConnection): Promise<McpToolInfo[] | 'retry'> => {
+        const collected: McpToolInfo[] = []
+        try {
+          let cursor: string | undefined
+          do {
+            const result = await c.client.listTools({ cursor })
+            for (const tool of result.tools) {
+              collected.push({
+                serverName: c.name,
+                name: tool.name,
+                description: tool.description ?? '',
+                inputSchema: (tool.inputSchema as Record<string, unknown>) ?? {},
+                isPublic: this.isToolPublic(tool.name, access),
+              })
+            }
+            cursor = result.nextCursor
+          } while (cursor)
+          return collected
+        } catch (err) {
+          this.logger.warn(`Error listing tools from MCP server "${c.name}": ${err}. Attempting reconnect...`)
+          return 'retry'
+        }
+      }
+
+      let tools = await fetchOnce(conn)
+      if (tools === 'retry') {
+        const ok = await this.reconnectShared(conn.name)
+        if (ok) {
+          const newConn = this.connections.find((c) => c.name === def.name)
+          if (newConn) tools = await fetchOnce(newConn)
+        }
+      }
+      if (tools !== 'retry') {
+        allTools.push(...tools)
+      } else {
+        this.logger.error(`Giving up on listTools for "${def.name}" after reconnect attempt.`)
       }
     }
 
@@ -182,12 +212,15 @@ export class McpService implements OnModuleInit, OnModuleDestroy {
     args: Record<string, unknown>,
     isAdmin = false,
   ): Promise<string> {
-    const sharedConn = this.connections.find((c) => c.name === serverName) ?? null
     const accessMode = this.accessModeMap.get(serverName)
+    let sharedConn = this.connections.find((c) => c.name === serverName) ?? null
 
-    // For admin-controlled servers, a shared connection is required
+    // For admin-controlled servers, a shared connection is required — attempt to (re)connect if missing
     if (!sharedConn && accessMode !== 'user-controlled') {
-      throw new Error(`MCP server "${serverName}" not connected.`)
+      const ok = await this.reconnectShared(serverName)
+      if (!ok) throw new Error(`MCP server "${serverName}" not connected.`)
+      sharedConn = this.connections.find((c) => c.name === serverName) ?? null
+      if (!sharedConn) throw new Error(`MCP server "${serverName}" not connected.`)
     }
 
     // Execution guard: reject admin-only tools for non-admin callers
@@ -207,7 +240,23 @@ export class McpService implements OnModuleInit, OnModuleDestroy {
       return 'You need to configure your credentials for this service first. Use the "MCP Server Config" menu option.'
     }
 
-    const result = await conn.client.callTool({ name: toolName, arguments: args })
+    const invoke = async (c: McpConnection) => c.client.callTool({ name: toolName, arguments: args })
+
+    // Only shared (admin-controlled) connections are auto-reconnected here.
+    // Per-user connections are recreated lazily via resolveConnection on next call.
+    const isShared = accessMode !== 'user-controlled'
+    let result
+    try {
+      result = await invoke(conn)
+    } catch (err) {
+      if (!isShared) throw err
+      this.logger.warn(`[MCP] callTool "${serverName}/${toolName}" failed: ${err}. Attempting reconnect and retry...`)
+      const ok = await this.reconnectShared(serverName)
+      if (!ok) throw err
+      const retryConn = this.connections.find((c) => c.name === serverName)
+      if (!retryConn) throw err
+      result = await invoke(retryConn)
+    }
 
     // Extract text content from the result
     if (result.content && Array.isArray(result.content)) {
@@ -309,9 +358,56 @@ export class McpService implements OnModuleInit, OnModuleDestroy {
     // Metadata may already have been registered in onModuleInit; set here as fallback for direct calls
     if (!this.toolAccessMap.has(def.name)) this.toolAccessMap.set(def.name, def.toolAccess)
     if (def.accessMode && !this.accessModeMap.has(def.name)) this.accessModeMap.set(def.name, def.accessMode)
+
+    // Attach close/error handlers so we can detect when the remote MCP server
+    // restarts or the transport dies, and drop the stale connection. The next
+    // listTools/callTool will then trigger a reconnect attempt.
+    transport.onclose = () => {
+      const idx = this.connections.findIndex((c) => c.name === def.name && c.transport === transport)
+      if (idx >= 0) {
+        this.connections.splice(idx, 1)
+        this.logger.warn(`[MCP] Transport closed for server "${def.name}". Will reconnect on next use.`)
+      }
+    }
+    transport.onerror = (err: unknown) => {
+      this.logger.warn(`[MCP] Transport error for server "${def.name}": ${err}`)
+    }
+
     this.logger.log(
       `Connected to MCP server "${def.name}" via ${def.transport}. accessMode=${def.accessMode ?? 'admin-controlled'}, toolAccess: ${def.toolAccess ? `default=${def.toolAccess.default}` : 'none (all public)'}`,
     )
+  }
+
+  /**
+   * Closes any stale shared connection for the given server and reconnects.
+   * Bumps toolsVersion so LlmService refreshes its tool cache.
+   * Returns true if reconnection succeeded.
+   */
+  private async reconnectShared(serverName: string): Promise<boolean> {
+    const def = this.serverDefs.find((d) => d.name === serverName)
+    if (!def) return false
+
+    // Drop any existing connection for this server (may already be gone via onclose)
+    const idx = this.connections.findIndex((c) => c.name === serverName)
+    if (idx >= 0) {
+      const stale = this.connections[idx]
+      this.connections.splice(idx, 1)
+      try {
+        await stale.client.close()
+      } catch {
+        /* ignore */
+      }
+    }
+
+    try {
+      await this.connectServer(def)
+      this._toolsVersion++
+      this.logger.log(`[MCP] Reconnected to server "${serverName}" (toolsVersion=${this._toolsVersion}).`)
+      return true
+    } catch (err) {
+      this.logger.error(`[MCP] Failed to reconnect server "${serverName}": ${err}`)
+      return false
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When an admin-controlled MCP server (e.g. `x-twitter` / `x-autonomous-mcp`) restarts — a pod reschedule, OOM kill, deploy, etc. — the `StreamableHTTPClientTransport` session dies. Subsequent `listTools` / `callTool` invocations from the chatbot fail, and the LLM reports "no MCP tools available" to the user until the chatbot pod itself is bounced.

## Fix

Shared MCP connections are now self-healing:

- **`connectServer`** attaches `transport.onclose` / `onerror` handlers that drop the stale connection from the list, so the next use triggers a fresh connect attempt.
- **New `reconnectShared(name)` helper** closes any stale connection and re-connects using the stored server def, bumping `_toolsVersion` so `LlmService` rebuilds its tool cache on the next `refreshMcpTools()` call.
- **`listTools`** now iterates over server defs (not just the live connection list). For each, if the connection is missing or `listTools` fails, it retries once via `reconnectShared`.
- **`callTool`** catches errors on shared connections and retries once after reconnecting.

Per-user (user-controlled) connections are not affected by this retry path — they are already recreated lazily via `resolveConnection` on the next call, and invalidated when the user updates credentials.

## Verification

- `npx tsc --noEmit` ✓
- `npx prettier --check "src/**/*.ts"` ✓
- `npx jest --passWithNoTests` ✓ (5/5)