### PR TITLE
fix(media): guide LLM to correct MCP server name for upload_media_to_mcp

### DIFF
--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -251,6 +251,15 @@ export class McpService implements OnModuleInit, OnModuleDestroy {
     return this.serverDefs.length > 0
   }
 
+  /**
+   * Returns the names of all configured MCP servers (from the agent pack / env),
+   * regardless of whether they are currently connected. Useful for building tool
+   * schemas that need to reference valid server names.
+   */
+  getServerNames(): string[] {
+    return this.serverDefs.map((d) => d.name)
+  }
+
   /** Per-server tool access configuration, keyed by server name */
   private readonly toolAccessMap = new Map<string, McpToolAccess | undefined>()
 

--- a/src/media/tools/upload-media-bridge.tool.ts
+++ b/src/media/tools/upload-media-bridge.tool.ts
@@ -13,6 +13,12 @@ const ToolCtor = DynamicStructuredTool as unknown as new (fields: any) => Dynami
  * and calls the MCP tool internally — keeping large binary data out of the LLM context.
  */
 export function createUploadMediaBridgeTool(refStore: ImageRefStore, mcpService: McpService): DynamicStructuredTool {
+  const serverNames = mcpService.getServerNames()
+  const serverHint =
+    serverNames.length > 0
+      ? `One of: ${serverNames.map((n) => `"${n}"`).join(', ')}.`
+      : 'The name of a configured MCP server.'
+
   return new ToolCtor({
     name: 'upload_media_to_mcp',
     description:
@@ -21,7 +27,7 @@ export function createUploadMediaBridgeTool(refStore: ImageRefStore, mcpService:
       'Returns the result from the MCP tool (e.g. a media_id for attaching to posts).',
     schema: z.object({
       ref_id: z.string().describe('The refId returned by generate_image for the image to upload'),
-      server: z.string().describe('MCP server name (e.g. "x-mcp")'),
+      server: z.string().describe(`MCP server name. ${serverHint}`),
       tool: z.string().describe('MCP tool name for media upload (e.g. "upload_media")'),
       extra_args: z
         .record(z.string())
@@ -33,6 +39,19 @@ export function createUploadMediaBridgeTool(refStore: ImageRefStore, mcpService:
     }),
     func: async (args) => {
       try {
+        // Validate server name against the current configuration. This catches
+        // LLM hallucinations early and tells the model exactly which names are
+        // valid so it can retry correctly.
+        const knownServers = mcpService.getServerNames()
+        if (knownServers.length > 0 && !knownServers.includes(args.server)) {
+          const msg =
+            `Unknown MCP server "${args.server}". ` +
+            `Available servers: ${knownServers.map((n) => `"${n}"`).join(', ')}. ` +
+            `Retry with one of these names.`
+          logger.warn(`upload_media_to_mcp: ${msg}`)
+          return JSON.stringify({ status: 'error', message: msg })
+        }
+
         const ref = refStore.get(args.ref_id)
         if (!ref) {
           return JSON.stringify({


### PR DESCRIPTION
## Problem

Reported on `x-agent`: posting a tweet **without** media works; posting the **same tweet with an image** fails. Chatbot logs show:

```
upload_media_to_mcp({"ref_id":"...","server":"x-mcp","tool":"upload_media"})
 → {"status":"error","message":"MCP server \"x-mcp\" not connected."}
```

But `post_tweet` succeeded as `mcp_x-twitter_post_tweet(...)` in the same session. The MCP server's actual configured name is `x-twitter` (agent-pack.yaml), not `x-mcp`.

## Root cause

`@/src/media/tools/upload-media-bridge.tool.ts:24` hardcoded a misleading example:

```ts
server: z.string().describe('MCP server name (e.g. "x-mcp")'),
```

The LLM obediently followed the schema example and passed `server: "x-mcp"`. Since no server with that name exists, `McpService.callTool` throws "not connected". The error message is accurate but doesn't hint at the real server name, so the LLM can't self-correct — it loops telling the user "reconnect the X MCP server".

Only `upload_media_to_mcp` hits this; other MCP tools are pre-wrapped as `mcp_<serverName>_<toolName>` by LangChain so the server name is already baked in.

## Fix

**1. Dynamic description**

The tool factory now reads `mcpService.getServerNames()` at creation time and embeds the real server list into the schema description:

```
server: MCP server name. One of: "x-twitter".
```

**2. Runtime guard**

Before invoking `McpService.callTool`, the bridge validates `args.server` against the configured server list. On mismatch it returns:

```json
{
  "status": "error",
  "message": "Unknown MCP server \"x-mcp\". Available servers: \"x-twitter\". Retry with one of these names."
}
```

This lets the LLM self-correct on the next call rather than looping.

**3. `McpService.getServerNames()`**

Small accessor exposing configured server names. Reusable by any future tool that needs the list.

## Verification

- `npx tsc --noEmit` ✓
- `npx jest --passWithNoTests` ✓ 5/5
- Manual code review of the two log paths (x-agent flow vs. other packs)

## Related

- Companion PR #86 (auto-reconnect): these two together eliminate the two separate "MCP server not connected" scenarios the user hit today.