### PR TITLE
feat(media): add openai-gpt-image provider for gpt-image-1.x models

### DIFF
--- a/docs/agent-pack-schema.md
+++ b/docs/agent-pack-schema.md
@@ -496,15 +496,24 @@ Configures AI image generation. The agent exposes two built-in LangChain tools (
 
 #### imageGeneration.providers[]
 
-| Field         | Type   | Default          | Description                                                                    |
-| ------------- | ------ | ---------------- | ------------------------------------------------------------------------------ |
-| `name`        | string | —                | Unique provider name, referenced by the LLM in `generate_image` tool calls.   |
-| `type`        | string | —                | Provider type. Currently supported: `openai-dalle`.                            |
-| `model`       | string | `dall-e-3`       | Model name (e.g. `dall-e-3`, `dall-e-2`).                                     |
-| `apiKeyEnv`   | string | `OPENAI_API_KEY` | Environment variable name holding the API key.                                 |
-| `defaultSize` | string | `1024x1024`      | Default image size (e.g. `1024x1024`, `1792x1024`). Provider interprets this. |
+| Field          | Type   | Default          | Description                                                                                    |
+| -------------- | ------ | ---------------- | ---------------------------------------------------------------------------------------------- |
+| `name`         | string | —                | Unique provider name, referenced by the LLM in `generate_image` tool calls.                    |
+| `type`         | string | —                | Provider type. Supported: `openai-dalle`, `openai-gpt-image`.                                  |
+| `model`        | string | depends on type  | Model name (e.g. `dall-e-3`, `dall-e-2`, `gpt-image-1`, `gpt-image-1.5`).                      |
+| `apiKeyEnv`    | string | `OPENAI_API_KEY` | Environment variable name holding the API key.                                                 |
+| `defaultSize`  | string | `1024x1024`      | Default image size. Provider interprets this — see per-type notes below.                       |
+| `quality`      | enum   | provider default | `openai-gpt-image` only: `low` \| `medium` \| `high` \| `auto`.                                |
+| `outputFormat` | enum   | `png`            | `openai-gpt-image` only: `png` \| `jpeg` \| `webp`. Native format returned by the API.         |
+| `background`   | enum   | provider default | `openai-gpt-image` only: `transparent` \| `opaque` \| `auto`.                                  |
+
+##### Type-specific notes
+
+- **`openai-dalle`** — sizes `1024x1024`, `1792x1024`, `1024x1792` (dall-e-3) or `256x256` / `512x512` / `1024x1024` (dall-e-2). Always returns PNG.
+- **`openai-gpt-image`** — sizes `1024x1024`, `1024x1536`, `1536x1024`, or `auto`. Does **not** accept `response_format`; native format is controlled by `outputFormat`. Supports up to `n=10` per call.
 
 ```yaml
+# DALL-E 3
 imageGeneration:
   providers:
     - name: dalle
@@ -512,6 +521,19 @@ imageGeneration:
       model: dall-e-3
       # apiKeyEnv: OPENAI_API_KEY  # default, reuses the LLM key
       defaultSize: 1024x1024
+```
+
+```yaml
+# gpt-image-1.5
+imageGeneration:
+  providers:
+    - name: gpt-image
+      type: openai-gpt-image
+      model: gpt-image-1.5
+      defaultSize: 1024x1024
+      quality: high
+      outputFormat: png
+      # background: transparent  # optional
 ```
 
 #### MinIO storage (environment variables)

--- a/src/config/agent-pack.loader.ts
+++ b/src/config/agent-pack.loader.ts
@@ -185,6 +185,10 @@ const AgentPackSchema = z
               model: z.string().optional(),
               apiKeyEnv: z.string().optional(),
               defaultSize: z.string().optional(),
+              // openai-gpt-image only (ignored by other provider types):
+              quality: z.enum(['low', 'medium', 'high', 'auto']).optional(),
+              outputFormat: z.enum(['png', 'jpeg', 'webp']).optional(),
+              background: z.enum(['transparent', 'opaque', 'auto']).optional(),
             }),
           )
           .optional(),

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -319,6 +319,10 @@ export default registerAs('appConfig', () => ({
     model?: string
     apiKeyEnv?: string
     defaultSize?: string
+    // openai-gpt-image only:
+    quality?: 'low' | 'medium' | 'high' | 'auto'
+    outputFormat?: 'png' | 'jpeg' | 'webp'
+    background?: 'transparent' | 'opaque' | 'auto'
   }[],
 
   // Speech-to-Text Configuration

--- a/src/media/providers/gpt-image.provider.ts
+++ b/src/media/providers/gpt-image.provider.ts
@@ -19,12 +19,7 @@ import type {
  *  - `n` can be up to 10 in a single call; no per-request dall-e-3 workaround.
  */
 export class GptImageProvider implements ImageProvider {
-  private static readonly SUPPORTED_SIZES = new Set([
-    '1024x1024',
-    '1024x1536',
-    '1536x1024',
-    'auto',
-  ])
+  private static readonly SUPPORTED_SIZES = new Set(['1024x1024', '1024x1536', '1536x1024', 'auto'])
 
   readonly name: string
   private readonly client: OpenAI

--- a/src/media/providers/gpt-image.provider.ts
+++ b/src/media/providers/gpt-image.provider.ts
@@ -1,0 +1,94 @@
+import OpenAI from 'openai'
+import type {
+  ImageProvider,
+  ImageProviderConfig,
+  ImageGenerationOptions,
+  GeneratedImage,
+} from './image-provider.interface'
+
+/**
+ * OpenAI gpt-image-* family provider (gpt-image-1, gpt-image-1.5, ...).
+ *
+ * Differences vs DalleProvider:
+ *  - `response_format` is NOT supported by the gpt-image models and must be
+ *    omitted. They always return `b64_json` inline. Passing `response_format`
+ *    yields a 400 from the API (see OpenAI Images API reference).
+ *  - Supported sizes are `1024x1024`, `1024x1536`, `1536x1024`, and `auto` —
+ *    the DALL-E 3 sizes (`1792x1024`, `1024x1792`) are rejected.
+ *  - Extra tunables: `quality`, `output_format`, `background`.
+ *  - `n` can be up to 10 in a single call; no per-request dall-e-3 workaround.
+ */
+export class GptImageProvider implements ImageProvider {
+  private static readonly SUPPORTED_SIZES = new Set([
+    '1024x1024',
+    '1024x1536',
+    '1536x1024',
+    'auto',
+  ])
+
+  readonly name: string
+  private readonly client: OpenAI
+  private readonly model: string
+  private readonly defaultSize: string
+  private readonly quality?: 'low' | 'medium' | 'high' | 'auto'
+  private readonly outputFormat: 'png' | 'jpeg' | 'webp'
+  private readonly background?: 'transparent' | 'opaque' | 'auto'
+
+  constructor(config: ImageProviderConfig) {
+    this.name = config.name
+    this.model = config.model ?? 'gpt-image-1.5'
+    this.defaultSize = config.defaultSize ?? '1024x1024'
+    this.quality = config.quality
+    this.outputFormat = config.outputFormat ?? 'png'
+    this.background = config.background
+
+    const apiKey = config.apiKeyEnv ? process.env[config.apiKeyEnv] : process.env.OPENAI_API_KEY
+    if (!apiKey) {
+      throw new Error(
+        `GptImageProvider "${config.name}": missing API key. ` +
+          `Set ${config.apiKeyEnv ?? 'OPENAI_API_KEY'} in the environment.`,
+      )
+    }
+
+    this.client = new OpenAI({ apiKey })
+  }
+
+  async generate(prompt: string, options?: ImageGenerationOptions): Promise<GeneratedImage[]> {
+    const n = Math.min(Math.max(options?.n ?? 1, 1), 10)
+    const requestedSize = options?.size ?? this.defaultSize
+    const size = GptImageProvider.SUPPORTED_SIZES.has(requestedSize)
+      ? (requestedSize as '1024x1024' | '1024x1536' | '1536x1024' | 'auto')
+      : '1024x1024'
+
+    // Build params explicitly — do NOT include `response_format`; the gpt-image
+    // models reject it and always stream back `b64_json` inline.
+    const params: Record<string, unknown> = {
+      model: this.model,
+      prompt,
+      n,
+      size,
+      output_format: this.outputFormat,
+    }
+    if (this.quality) params.quality = this.quality
+    if (this.background) params.background = this.background
+
+    // Cast through `unknown`: the installed SDK's typings model only the
+    // DALL-E shape, but gpt-image accepts `output_format` / `quality` /
+    // `background` which we need to pass through.
+    const response = await this.client.images.generate(
+      params as unknown as Parameters<typeof this.client.images.generate>[0],
+    )
+
+    const mimeType = `image/${this.outputFormat}`
+    const images: GeneratedImage[] = []
+    for (const item of response.data ?? []) {
+      if (item.b64_json) {
+        images.push({
+          buffer: Buffer.from(item.b64_json, 'base64'),
+          mimeType,
+        })
+      }
+    }
+    return images
+  }
+}

--- a/src/media/providers/image-provider.factory.ts
+++ b/src/media/providers/image-provider.factory.ts
@@ -1,5 +1,6 @@
 import type { ImageProvider, ImageProviderConfig } from './image-provider.interface'
 import { DalleProvider } from './dalle.provider'
+import { GptImageProvider } from './gpt-image.provider'
 
 /**
  * Creates an ImageProvider instance based on the provider type in the config.
@@ -9,6 +10,8 @@ export function createImageProvider(config: ImageProviderConfig): ImageProvider 
   switch (config.type) {
     case 'openai-dalle':
       return new DalleProvider(config)
+    case 'openai-gpt-image':
+      return new GptImageProvider(config)
     default:
       throw new Error(`Unknown image generation provider type: "${config.type}"`)
   }

--- a/src/media/providers/image-provider.interface.ts
+++ b/src/media/providers/image-provider.interface.ts
@@ -22,14 +22,20 @@ export interface ImageGenerationOptions {
 export interface ImageProviderConfig {
   /** Unique name used to reference this provider in tool calls. */
   name: string
-  /** Provider type identifier (e.g. "openai-dalle", "stability-ai"). */
+  /** Provider type identifier (e.g. "openai-dalle", "openai-gpt-image", "stability-ai"). */
   type: string
-  /** Model name (e.g. "dall-e-3", "stable-diffusion-xl-1024-v1-0"). */
+  /** Model name (e.g. "dall-e-3", "gpt-image-1.5", "stable-diffusion-xl-1024-v1-0"). */
   model?: string
   /** Environment variable name holding the API key (omit if shared with LLM). */
   apiKeyEnv?: string
   /** Default generation size (e.g. "1024x1024"). */
   defaultSize?: string
+  /** gpt-image only: rendering quality. */
+  quality?: 'low' | 'medium' | 'high' | 'auto'
+  /** gpt-image only: native output format returned by the API. */
+  outputFormat?: 'png' | 'jpeg' | 'webp'
+  /** gpt-image only: background handling. */
+  background?: 'transparent' | 'opaque' | 'auto'
 }
 
 /**


### PR DESCRIPTION
## Why

Only `openai-dalle` was wired up. Pointing an agent-pack at `model: gpt-image-1.5` under `type: openai-dalle` does **not** work:

1. `DalleProvider` hardcodes `response_format: 'b64_json'`. Per the [OpenAI Images reference](https://developers.openai.com/api/reference/resources/images/methods/generate), that parameter is *"Unsupported for the GPT image models."* — the API rejects the call outright.
2. DALL-E 3's `1792x1024` / `1024x1792` sizes are not accepted by gpt-image (its set is `1024x1024`, `1024x1536`, `1536x1024`, `auto`).

## What

New dedicated provider type `openai-gpt-image`:

- **`src/media/providers/gpt-image.provider.ts`** (new) — `ImageProvider` implementation that:
  - Omits `response_format` (gpt-image always streams `b64_json` inline).
  - Validates size against the gpt-image set and falls back to `1024x1024` instead of erroring the call.
  - Honors new config fields `quality`, `outputFormat`, `background`.
  - Caps `n` at 10 (gpt-image's native limit).
  - Sets the returned `mimeType` from `outputFormat` so `ImageConverterService` sees the correct source type.
- **`image-provider.factory.ts`** — registers `openai-gpt-image` ↦ `GptImageProvider`.
- **`image-provider.interface.ts`** — extends `ImageProviderConfig` with optional `quality` / `outputFormat` / `background`. All optional → existing `openai-dalle` configs are untouched.
- **`config/agent-pack.loader.ts`** — widens Zod schema for `imageGeneration.providers[]` with `z.enum([...])` on the three new fields so invalid values fail at load time.
- **`config/app.config.ts`** — widens the inline type of `imageGenerationProviders` so the fields survive `ConfigService` handoff.
- **`docs/agent-pack-schema.md`** — documents the new type, per-type notes (sizes, output format, `n` cap), and a worked `gpt-image-1.5` YAML example alongside the existing DALL-E one.

## Example config

```yaml
imageGeneration:
  providers:
    - name: gpt-image
      type: openai-gpt-image
      model: gpt-image-1.5
      defaultSize: 1024x1024
      quality: high
      outputFormat: png
      # background: transparent  # optional
```

## Verification

- `pnpm tsc --noEmit` clean
- `pnpm test` → all 5 jest suites green
- Existing `openai-dalle` configs not touched; Zod schema change is additive.

## Rollout

- Merge → release-please bumps the app version.
- `io2060/hologram-generic-ai-agent-app:<new-tag>` published.
- `CHATBOT_IMAGE` in consumer repos (e.g. `x-agent/config.env`) bumped to pick it up.
- Consumer agent-packs can then switch `imageGeneration.providers[*].type` to `openai-gpt-image`.

## Rollback

Additive change, no behaviour change for existing DALL-E users — revert is safe.