### PR TITLE
feat(vision): add image-to-text description for incoming media

### DIFF
--- a/docs/agent-pack-schema.md
+++ b/docs/agent-pack-schema.md
@@ -622,6 +622,78 @@ If not overridden, the following defaults are used:
 
 ---
 
+### vision
+
+Configures image-to-text description (vision). When enabled, incoming image `MediaMessage` items are described by a vision-capable LLM and injected into the chat flow as `[Image] <description>` so the main LLM has textual context to reason over. Non-image media (documents, etc.) is unaffected.
+
+| Field         | Type           | Default | Description                                                            |
+| ------------- | -------------- | ------- | ---------------------------------------------------------------------- |
+| `requireAuth` | boolean/string | `false` | When `true`, images from unauthenticated users are rejected.           |
+| `provider`    | object         | —       | Vision provider configuration (see below). If omitted, vision is disabled. |
+
+#### vision.provider
+
+| Field       | Type   | Default          | Description                                                                                         |
+| ----------- | ------ | ---------------- | --------------------------------------------------------------------------------------------------- |
+| `name`      | string | —                | Unique provider name (for logging).                                                                 |
+| `type`      | string | —                | Provider type: `openai-vision` (OpenAI cloud) or `openai-compatible-vision` (self-hosted endpoint). |
+| `model`     | string | `gpt-4o-mini`    | Vision-capable model name (e.g. `gpt-4o`, `gpt-4o-mini`, `gpt-4.1-mini`).                           |
+| `apiKeyEnv` | string | `OPENAI_API_KEY` | Environment variable name containing the API key.                                                   |
+| `baseUrl`   | string | —                | Base URL for OpenAI-compatible endpoints (e.g. `https://my-llm.example.com/v1`).                    |
+| `prompt`    | string | built-in concise-description prompt | Prompt used when asking the model to describe the image. Useful to tune verbosity or domain focus. |
+| `maxTokens` | number | `300`            | Max tokens for the description output.                                                              |
+| `detail`    | enum   | `auto`           | OpenAI image detail hint: `auto`, `low`, or `high`. `low` is cheaper; `high` is more accurate.      |
+| `language`  | string | —                | Optional language hint for the description (ISO 639-1, e.g. `en`, `es`).                            |
+
+Both `openai-vision` and `openai-compatible-vision` use the same OpenAI-compatible `/v1/chat/completions` API with an `image_url` content block containing a `data:` URI. The difference is that `openai-compatible-vision` is intended for self-hosted endpoints where `baseUrl` is required and `apiKeyEnv` may not be needed.
+
+```yaml
+# Example: OpenAI cloud vision
+vision:
+  requireAuth: true
+  provider:
+    name: vision
+    type: openai-vision
+    model: gpt-4o-mini
+    detail: auto
+    # apiKeyEnv: OPENAI_API_KEY  # default
+
+# Example: Self-hosted OpenAI-compatible vision endpoint
+vision:
+  requireAuth: false
+  provider:
+    name: local-vision
+    type: openai-compatible-vision
+    model: llava-next
+    baseUrl: https://my-llm.example.com/v1
+    prompt: "Describe the key visual elements of this image in one short paragraph."
+    maxTokens: 200
+```
+
+#### Image authentication message
+
+When `requireAuth: true` and an unauthenticated user sends an image, the agent sends an `IMAGE_AUTH_REQUIRED` message. This message is configurable per language via the `strings` map:
+
+```yaml
+languages:
+  en:
+    strings:
+      IMAGE_AUTH_REQUIRED: "Please log in before sending images."
+  es:
+    strings:
+      IMAGE_AUTH_REQUIRED: "Inicia sesión antes de enviar imágenes."
+```
+
+If not overridden, the following defaults are used:
+
+| Language | Default message |
+| -------- | --------------- |
+| `en`     | Images require authentication. Please authenticate first to use this feature. |
+| `es`     | Las imágenes requieren autenticación. Por favor, autentícate primero para usar esta función. |
+| `fr`     | Les images nécessitent une authentification. Veuillez vous authentifier d'abord pour utiliser cette fonctionnalité. |
+
+---
+
 ### integrations
 
 Free-form configuration for external services. The schema accepts any structure under `vsAgent` and `postgres`.

--- a/src/config/agent-pack.loader.ts
+++ b/src/config/agent-pack.loader.ts
@@ -205,6 +205,24 @@ const AgentPackSchema = z
           .optional(),
       })
       .optional(),
+    vision: z
+      .object({
+        requireAuth: z.union([z.boolean(), z.string()]).optional(),
+        provider: z
+          .object({
+            name: z.string(),
+            type: z.string(),
+            model: z.string().optional(),
+            apiKeyEnv: z.string().optional(),
+            baseUrl: z.string().optional(),
+            prompt: z.string().optional(),
+            maxTokens: z.number().optional(),
+            detail: z.enum(['auto', 'low', 'high']).optional(),
+            language: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional(),
     integrations: z
       .object({
         vsAgent: z.any().optional(),

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -333,4 +333,20 @@ export default registerAs('appConfig', () => ({
       })
     : undefined,
   sttRequireAuth: agentPack?.speechToText?.requireAuth === true || agentPack?.speechToText?.requireAuth === 'true',
+
+  // Vision (image-to-text) Configuration
+  visionProvider: agentPack?.vision?.provider
+    ? (agentPack.vision.provider as {
+        name: string
+        type: string
+        model?: string
+        apiKeyEnv?: string
+        baseUrl?: string
+        prompt?: string
+        maxTokens?: number
+        detail?: 'auto' | 'low' | 'high'
+        language?: string
+      })
+    : undefined,
+  visionRequireAuth: agentPack?.vision?.requireAuth === true || agentPack?.vision?.requireAuth === 'true',
 }))

--- a/src/core/common/i18n/i18n.ts
+++ b/src/core/common/i18n/i18n.ts
@@ -66,8 +66,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
       'Aún no tienes la credencial requerida. Aquí tienes una invitación al servicio que puede emitirla:',
     VOICE_AUTH_REQUIRED:
       'Los mensajes de voz requieren autenticación. Por favor, autentícate primero para usar esta función.',
-    IMAGE_AUTH_REQUIRED:
-      'Las imágenes requieren autenticación. Por favor, autentícate primero para usar esta función.',
+    IMAGE_AUTH_REQUIRED: 'Las imágenes requieren autenticación. Por favor, autentícate primero para usar esta función.',
   },
   fr: {
     ROOT_TITLE: 'Bienvenue !',

--- a/src/core/common/i18n/i18n.ts
+++ b/src/core/common/i18n/i18n.ts
@@ -32,6 +32,7 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
     AUTH_NO_CREDENTIAL:
       "You don't have the required credential yet. Here is an invitation to the service that can issue it:",
     VOICE_AUTH_REQUIRED: 'Voice messages require authentication. Please authenticate first to use this feature.',
+    IMAGE_AUTH_REQUIRED: 'Images require authentication. Please authenticate first to use this feature.',
   },
   es: {
     ROOT_TITLE: '¡Bienvenido!',
@@ -65,6 +66,8 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
       'Aún no tienes la credencial requerida. Aquí tienes una invitación al servicio que puede emitirla:',
     VOICE_AUTH_REQUIRED:
       'Los mensajes de voz requieren autenticación. Por favor, autentícate primero para usar esta función.',
+    IMAGE_AUTH_REQUIRED:
+      'Las imágenes requieren autenticación. Por favor, autentícate primero para usar esta función.',
   },
   fr: {
     ROOT_TITLE: 'Bienvenue !',
@@ -98,6 +101,8 @@ export const DEFAULT_TRANSLATIONS: Record<string, Record<string, string>> = {
       "Vous n'avez pas encore le justificatif requis. Voici une invitation au service qui peut vous le délivrer :",
     VOICE_AUTH_REQUIRED:
       "Les messages vocaux nécessitent une authentification. Veuillez vous authentifier d'abord pour utiliser cette fonctionnalité.",
+    IMAGE_AUTH_REQUIRED:
+      "Les images nécessitent une authentification. Veuillez vous authentifier d'abord pour utiliser cette fonctionnalité.",
   },
 }
 

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -7,6 +7,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config'
 import { ChatbotModule } from '../chatbot/chatbot.module'
 import { MemoryModule } from '../memory/memory.module'
 import { SttModule } from '../stt/stt.module'
+import { VisionModule } from '../vision/vision.module'
 import { AgentContentService } from './agent-content.service'
 import { McpConfigEntity } from '../mcp/mcp-config.entity'
 import { ApprovalRequestEntity } from '../rbac/approval-request.entity'
@@ -36,6 +37,7 @@ import { ApprovalRequestEntity } from '../rbac/approval-request.entity'
     ChatbotModule,
     MemoryModule,
     SttModule,
+    VisionModule,
     EventsModule,
   ],
   controllers: [],

--- a/src/core/core.service.ts
+++ b/src/core/core.service.ts
@@ -37,6 +37,7 @@ import { RbacService } from '../rbac/rbac.service'
 import { ApprovalService } from '../rbac/approval.service'
 import type { AuthFlowConfig } from '../config/agent-pack.loader'
 import { SttService } from '../stt/stt.service'
+import { VisionService } from '../vision/vision.service'
 
 @Injectable()
 export class CoreService implements EventHandler, OnModuleInit {
@@ -56,6 +57,7 @@ export class CoreService implements EventHandler, OnModuleInit {
     @Optional() private readonly rbacService: RbacService,
     @Optional() private readonly approvalService: ApprovalService,
     private readonly sttService: SttService,
+    private readonly visionService: VisionService,
   ) {
     const baseUrl = configService.get<string>('appConfig.vsAgentAdminUrl') || 'http://localhost:3001'
     this.apiClient = new ApiClient(baseUrl, ApiVersion.V1)
@@ -170,14 +172,49 @@ export class CoreService implements EventHandler, OnModuleInit {
               }
             }
           } else {
-            // Non-audio media: describe items so LLM has context
+            // Non-audio media: try vision (image-to-text) first, then fall
+            // back to a descriptive stub so the LLM always has context.
             const items = mediaMsg.items ?? []
-            const desc = items.map((it) => it.mimeType).join(', ')
-            content = new TextMessage({
-              connectionId: message.connectionId,
-              content: `[Media received: ${desc || 'unknown'}]`,
-              ...(message.threadId ? { threadId: message.threadId } : {}),
-            })
+            const imageItem = items.find((it) => this.visionService.isImageMimeType(it.mimeType))
+
+            if (imageItem && this.visionService.isEnabled) {
+              if (!this.visionService.isAllowed(session.isAuthenticated ?? false)) {
+                this.logger.log(`[Vision] Blocked image from unauthenticated user ${session.connectionId}`)
+                await this.sendText(
+                  session.connectionId,
+                  this.getText('IMAGE_AUTH_REQUIRED', session.lang),
+                  session.lang,
+                )
+              } else {
+                try {
+                  const result = await this.visionService.describeFromUrl(
+                    imageItem.uri,
+                    imageItem.mimeType,
+                    imageItem.ciphering,
+                  )
+                  if (result.text.trim().length > 0) {
+                    content = new TextMessage({
+                      connectionId: message.connectionId,
+                      content: `[Image] ${result.text.trim()}`,
+                      ...(message.threadId ? { threadId: message.threadId } : {}),
+                    })
+                  }
+                } catch (err) {
+                  this.logger.error(`[Vision] Description failed: ${err}`)
+                }
+              }
+            }
+
+            // Fallback stub when vision didn't produce content (not an image,
+            // not enabled, blocked, or errored).
+            if (!content) {
+              const desc = items.map((it) => it.mimeType).join(', ')
+              content = new TextMessage({
+                connectionId: message.connectionId,
+                content: `[Media received: ${desc || 'unknown'}]`,
+                ...(message.threadId ? { threadId: message.threadId } : {}),
+              })
+            }
           }
           break
         }

--- a/src/vision/providers/openai-vision.provider.ts
+++ b/src/vision/providers/openai-vision.provider.ts
@@ -1,0 +1,72 @@
+import OpenAI from 'openai'
+import type { DescriptionResult, VisionProvider, VisionProviderConfig } from './vision-provider.interface'
+
+const DEFAULT_PROMPT =
+  'Describe this image concisely but completely for an AI agent that will use ' +
+  'your description to respond to the user. Include: subject, setting, notable ' +
+  'objects, actions, any visible text, and mood. Do not add commentary or ' +
+  'interpretation beyond description. Keep it under 200 words.'
+
+/**
+ * Vision provider backed by OpenAI chat completions with image inputs
+ * (`image_url` content block). Also works with any OpenAI-compatible endpoint
+ * that accepts multimodal chat messages (set `baseUrl`).
+ */
+export class OpenAiVisionProvider implements VisionProvider {
+  readonly name: string
+  private readonly client: OpenAI
+  private readonly model: string
+  private readonly prompt: string
+  private readonly maxTokens: number
+  private readonly detail: 'low' | 'high' | 'auto'
+  private readonly language?: string
+
+  constructor(config: VisionProviderConfig) {
+    this.name = config.name
+    this.model = config.model ?? 'gpt-4o-mini'
+    this.prompt = config.prompt ?? DEFAULT_PROMPT
+    this.maxTokens = config.maxTokens ?? 500
+    this.detail = config.detail ?? 'auto'
+    this.language = config.language || undefined
+
+    const apiKey = config.apiKeyEnv ? process.env[config.apiKeyEnv] : process.env.OPENAI_API_KEY
+    if (!apiKey && !config.baseUrl) {
+      throw new Error(
+        `OpenAiVisionProvider "${config.name}": missing API key. ` +
+          `Set ${config.apiKeyEnv ?? 'OPENAI_API_KEY'} in the environment.`,
+      )
+    }
+
+    this.client = new OpenAI({
+      apiKey: apiKey || 'not-needed',
+      ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+    })
+  }
+
+  async describe(imageBuffer: Buffer, mimeType: string, promptOverride?: string): Promise<DescriptionResult> {
+    const dataUrl = `data:${mimeType};base64,${imageBuffer.toString('base64')}`
+    const instruction =
+      (promptOverride?.trim() || this.prompt) +
+      (this.language ? `\n\nRespond in language: ${this.language}.` : '')
+
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      max_tokens: this.maxTokens,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: instruction },
+            { type: 'image_url', image_url: { url: dataUrl, detail: this.detail } },
+          ],
+        },
+      ],
+    })
+
+    const text = response.choices?.[0]?.message?.content ?? ''
+    return {
+      text: typeof text === 'string' ? text : JSON.stringify(text),
+      model: response.model,
+    }
+  }
+}

--- a/src/vision/providers/openai-vision.provider.ts
+++ b/src/vision/providers/openai-vision.provider.ts
@@ -46,8 +46,7 @@ export class OpenAiVisionProvider implements VisionProvider {
   async describe(imageBuffer: Buffer, mimeType: string, promptOverride?: string): Promise<DescriptionResult> {
     const dataUrl = `data:${mimeType};base64,${imageBuffer.toString('base64')}`
     const instruction =
-      (promptOverride?.trim() || this.prompt) +
-      (this.language ? `\n\nRespond in language: ${this.language}.` : '')
+      (promptOverride?.trim() || this.prompt) + (this.language ? `\n\nRespond in language: ${this.language}.` : '')
 
     const response = await this.client.chat.completions.create({
       model: this.model,

--- a/src/vision/providers/vision-provider.factory.ts
+++ b/src/vision/providers/vision-provider.factory.ts
@@ -1,0 +1,16 @@
+import type { VisionProvider, VisionProviderConfig } from './vision-provider.interface'
+import { OpenAiVisionProvider } from './openai-vision.provider'
+
+/**
+ * Creates a VisionProvider instance based on the provider type in the config.
+ * Add new providers here as they are implemented.
+ */
+export function createVisionProvider(config: VisionProviderConfig): VisionProvider {
+  switch (config.type) {
+    case 'openai-vision':
+    case 'openai-compatible-vision':
+      return new OpenAiVisionProvider(config)
+    default:
+      throw new Error(`Unknown vision provider type: "${config.type}"`)
+  }
+}

--- a/src/vision/providers/vision-provider.interface.ts
+++ b/src/vision/providers/vision-provider.interface.ts
@@ -1,0 +1,47 @@
+/**
+ * Result returned by a vision provider.
+ */
+export interface DescriptionResult {
+  /** Textual description of the image contents. */
+  text: string
+  /** Model that produced the description (informational). */
+  model?: string
+}
+
+/**
+ * Provider-specific configuration loaded from agent-pack.yaml.
+ */
+export interface VisionProviderConfig {
+  /** Unique name used to reference this provider. */
+  name: string
+  /** Provider type identifier (e.g. "openai-vision"). */
+  type: string
+  /** Model name (e.g. "gpt-4o-mini", "gpt-5.4-mini"). */
+  model?: string
+  /** Environment variable name holding the API key. */
+  apiKeyEnv?: string
+  /** Base URL for the API. Empty = OpenAI cloud. Set for self-hosted. */
+  baseUrl?: string
+  /** System / instruction prompt guiding the description. */
+  prompt?: string
+  /** Max output tokens from the vision model. */
+  maxTokens?: number
+  /** OpenAI image_url `detail` hint. */
+  detail?: 'low' | 'high' | 'auto'
+  /** Optional output-language hint (ISO 639-1, e.g. "en", "es"). */
+  language?: string
+}
+
+/**
+ * All vision (image-to-text) providers must implement this interface.
+ */
+export interface VisionProvider {
+  readonly name: string
+  /**
+   * Produce a textual description of the supplied image.
+   * @param imageBuffer  Already-decrypted raw image bytes.
+   * @param mimeType     e.g. "image/jpeg", "image/png", "image/webp".
+   * @param promptOverride  Optional per-call prompt; falls back to the provider's configured prompt.
+   */
+  describe(imageBuffer: Buffer, mimeType: string, promptOverride?: string): Promise<DescriptionResult>
+}

--- a/src/vision/vision.module.ts
+++ b/src/vision/vision.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common'
+import { VisionService } from './vision.service'
+
+@Global()
+@Module({
+  providers: [VisionService],
+  exports: [VisionService],
+})
+export class VisionModule {}

--- a/src/vision/vision.service.ts
+++ b/src/vision/vision.service.ts
@@ -1,11 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { createDecipheriv } from 'crypto'
-import type {
-  DescriptionResult,
-  VisionProvider,
-  VisionProviderConfig,
-} from './providers/vision-provider.interface'
+import type { DescriptionResult, VisionProvider, VisionProviderConfig } from './providers/vision-provider.interface'
 import { createVisionProvider } from './providers/vision-provider.factory'
 
 export interface ImageCiphering {
@@ -87,11 +83,7 @@ export class VisionService implements OnModuleInit {
   /**
    * Download an image from a URL (decrypting if ciphered) and describe it.
    */
-  async describeFromUrl(
-    url: string,
-    mimeType: string,
-    ciphering?: ImageCiphering,
-  ): Promise<DescriptionResult> {
+  async describeFromUrl(url: string, mimeType: string, ciphering?: ImageCiphering): Promise<DescriptionResult> {
     if (!this.provider) {
       throw new Error('Vision provider is not configured.')
     }

--- a/src/vision/vision.service.ts
+++ b/src/vision/vision.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { createDecipheriv } from 'crypto'
+import type {
+  DescriptionResult,
+  VisionProvider,
+  VisionProviderConfig,
+} from './providers/vision-provider.interface'
+import { createVisionProvider } from './providers/vision-provider.factory'
+
+export interface ImageCiphering {
+  algorithm: string
+  parameters?: Record<string, unknown>
+}
+
+const IMAGE_MIME_PREFIXES = ['image/']
+
+/**
+ * Mirrors `SttService`: downloads an image (handling E2EE ciphering), asks a
+ * vision provider to describe it, and returns text that the caller injects
+ * back into the chat flow so the LLM has context.
+ *
+ * If `appConfig.visionPassthrough` is set to `true` the intention is to pass
+ * the raw image directly to a multimodal LLM instead of pre-describing it.
+ * That path is not yet implemented; this service logs a warning and falls
+ * back to describe-and-inject so the config surface is already stable for
+ * future work without breaking consumers today.
+ */
+@Injectable()
+export class VisionService implements OnModuleInit {
+  private readonly logger = new Logger(VisionService.name)
+  private provider: VisionProvider | null = null
+  private requireAuth = false
+  private passthrough = false
+
+  constructor(private readonly config: ConfigService) {}
+
+  async onModuleInit() {
+    const providerConfig = this.config.get<VisionProviderConfig>('appConfig.visionProvider')
+    this.requireAuth = this.config.get<boolean>('appConfig.visionRequireAuth') ?? false
+    this.passthrough = this.config.get<boolean>('appConfig.visionPassthrough') ?? false
+
+    if (!providerConfig) {
+      this.logger.log('No vision provider configured. Image media will not be described.')
+      return
+    }
+
+    if (this.passthrough) {
+      this.logger.warn(
+        'vision.passthrough=true was set but multimodal pass-through is not yet implemented. ' +
+          'Falling back to describe-and-inject.',
+      )
+    }
+
+    try {
+      this.provider = createVisionProvider(providerConfig)
+      this.logger.log(
+        `Vision provider "${providerConfig.name}" (${providerConfig.type}) initialized. ` +
+          `requireAuth=${this.requireAuth}`,
+      )
+    } catch (err) {
+      this.logger.error(`Failed to initialize vision provider "${providerConfig.name}": ${err}`)
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.provider !== null
+  }
+
+  /**
+   * True if the given MIME type is an image format that can be described.
+   */
+  isImageMimeType(mimeType: string): boolean {
+    return IMAGE_MIME_PREFIXES.some((prefix) => mimeType.toLowerCase().startsWith(prefix))
+  }
+
+  /**
+   * True when describe() is allowed for the caller's auth state.
+   * Returns false if no provider is configured or auth is required but missing.
+   */
+  isAllowed(isAuthenticated: boolean): boolean {
+    if (!this.isEnabled) return false
+    if (this.requireAuth && !isAuthenticated) return false
+    return true
+  }
+
+  /**
+   * Download an image from a URL (decrypting if ciphered) and describe it.
+   */
+  async describeFromUrl(
+    url: string,
+    mimeType: string,
+    ciphering?: ImageCiphering,
+  ): Promise<DescriptionResult> {
+    if (!this.provider) {
+      throw new Error('Vision provider is not configured.')
+    }
+
+    this.logger.log(`Downloading image for description (${mimeType})...`)
+
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to download image from ${url}: ${response.status}`)
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
+    let buffer: Buffer = Buffer.from(new Uint8Array(arrayBuffer))
+
+    if (ciphering) {
+      buffer = this.decrypt(buffer, ciphering)
+      this.logger.log(`Decrypted image (${ciphering.algorithm}): ${Math.round(buffer.length / 1024)}KB`)
+    }
+
+    this.logger.log(`Downloaded ${Math.round(buffer.length / 1024)}KB image. Describing...`)
+
+    const result = await this.provider.describe(buffer, mimeType)
+
+    this.logger.log(
+      `Description complete: "${result.text.slice(0, 120)}${result.text.length > 120 ? '...' : ''}"` +
+        ` (model=${result.model ?? 'unknown'})`,
+    )
+
+    return result
+  }
+
+  private decrypt(encrypted: Buffer, ciphering: ImageCiphering): Buffer {
+    const key = ciphering.parameters?.['key'] as string | undefined
+    const iv = ciphering.parameters?.['iv'] as string | undefined
+
+    if (!key || !iv) {
+      throw new Error(`Missing key or iv in ciphering parameters`)
+    }
+
+    const decipher = createDecipheriv(ciphering.algorithm, Buffer.from(key, 'hex'), Buffer.from(iv, 'hex'))
+    return Buffer.from(Buffer.concat([decipher.update(encrypted), decipher.final()]))
+  }
+}


### PR DESCRIPTION
## Summary

Adds a first-class **Vision** pipeline for incoming `MediaMessage` items so the chatbot can reason over images sent by users.

Approach is the hybrid "describe & inject" path we agreed on: a dedicated provider describes each image, and the description is injected into the chat flow as `[Image] <description>` — analogous to how `SttService` already injects `[Voice note] <transcription>`. This keeps the main LLM path unchanged and lays the groundwork for a future native-multimodal pass-through.

## Changes

- **`src/vision/`** (new module):
  - `VisionService` mirrors `SttService`: download → optional E2EE decrypt → provider-based description.
  - Pluggable provider interface + factory.
  - OpenAI vision provider (`openai-vision` + `openai-compatible-vision`) using chat completions with an `image_url` data-URI content block.
  - `@Global()` `VisionModule` registered once from `CoreModule`, so `VisionService` is injectable everywhere (same pattern as `SttModule`).
- **`CoreService.handleMessage`**: the non-audio `MediaMessage` branch now tries vision first (when the item is `image/*` and the service is enabled + auth allows it) and falls back to the existing stub if vision is disabled, blocked, or errors — no regressions for unconfigured agent-packs.
- **Config**: new `vision` block in `agent-pack.loader.ts` (Zod schema) and exposed as `visionProvider` / `visionRequireAuth` in `app.config.ts`. Supports `prompt`, `maxTokens`, `detail` (auto/low/high), and `language` knobs.
- **i18n**: `IMAGE_AUTH_REQUIRED` added for `en`/`es`/`fr` next to `VOICE_AUTH_REQUIRED`.
- **Docs**: new `vision` section in `docs/agent-pack-schema.md` mirroring the `speechToText` section, with examples for cloud and self-hosted setups and the image-auth message overrides.

## Example agent-pack

```yaml
vision:
  requireAuth: true
  provider:
    name: vision
    type: openai-vision
    model: gpt-4o-mini
    detail: auto
    # apiKeyEnv: OPENAI_API_KEY  # default
```

## Verification

- `pnpm exec tsc --noEmit` — clean.
- `pnpm test` — 5/5 suites pass.
- No behavior change for agent-packs without a `vision:` block (vision service logs "No vision provider configured" and the non-audio branch falls through to the existing stub).

## Follow-ups (future PRs)

- Native multimodal pass-through (bypass describe step when the main LLM itself is vision-capable). The `visionPassthrough` hook is already acknowledged in `VisionService` and can be wired without further schema work.
