### PR TITLE
chore: rename to hologram-ai-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🤖 hologram-generic-ai-agent-vs
+# 🤖 hologram-ai-agent
 
 A modular, multi-language AI agent built with NestJS for the Hologram + Verana ecosystem. Supports LLM integration (OpenAI, Ollama, Anthropic), RAG, MCP (Model Context Protocol) servers, verifiable credential authentication, and per-user tool configuration — all driven by a single `agent-pack.yaml` manifest.
 
@@ -66,8 +66,8 @@ charts/                    # Helm chart for Kubernetes deployment
 ### Step 1: Clone and install
 
 ```bash
-git clone git@github.com:2060-io/hologram-generic-ai-agent-vs.git
-cd hologram-generic-ai-agent-vs
+git clone git@github.com:2060-io/hologram-ai-agent.git
+cd hologram-ai-agent
 corepack enable
 pnpm install
 ```

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: hologram-generic-ai-agent-chart
+name: hologram-ai-agent-chart
 version: 1.3.2
 appVersion: '1.3.2'
-description: Helm chart to deploy Hologram Generic AI Agent Verifiable Service
+description: Helm chart to deploy Hologram AI Agent Verifiable Service
 dependencies:
   - name: vs-agent-chart
     version: v1.9.2

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,8 +1,8 @@
-# hologram-generic-ai-agent-vs Helm Chart
+# hologram-ai-agent Helm Chart
 
 ## Overview
 
-This Helm chart deploys the `hologram-generic-ai-agent-vs` application and all required Kubernetes components: `chatbot`, `vs-agent`, `postgres`, `redis`, `stats`, and (optional) `artemis`.
+This Helm chart deploys the `hologram-ai-agent` application and all required Kubernetes components: `chatbot`, `vs-agent`, `postgres`, `redis`, `stats`, and (optional) `artemis`.
 
 - The `vs-agent` component is deployed as a Helm dependency (`vs-agent-chart`) and configured entirely via `values.yaml`.
 

--- a/charts/templates/chatbot-deployment.yaml
+++ b/charts/templates/chatbot-deployment.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
         - name: chatbot
-          image: {{ .Values.image.repository | default "io2060/hologram-generic-ai-agent-app" }}:{{ .Values.image.tag | default .Chart.Version }}
+          image: {{ .Values.image.repository | default "io2060/hologram-ai-agent" }}:{{ .Values.image.tag | default .Chart.Version }}
           imagePullPolicy: {{ .Values.chatbot.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.chatbot.service.port }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hologram-generic-ai-agent-vs",
+  "name": "hologram-ai-agent",
   "version": "1.13.0",
   "description": "",
   "author": "",


### PR DESCRIPTION
Aligns the in-repo identifiers with the GitHub repository rename (`hologram-generic-ai-agent-vs` → `hologram-ai-agent`).

## Changes

- **`package.json`** — `name`: `hologram-generic-ai-agent-vs` → `hologram-ai-agent`
- **`charts/Chart.yaml`** — chart `name`: `hologram-generic-ai-agent-chart` → `hologram-ai-agent-chart`; description updated
- **`charts/templates/chatbot-deployment.yaml`** — default image repository: `io2060/hologram-generic-ai-agent-app` → `io2060/hologram-ai-agent`
- **`charts/README.md`** — references updated to the new chart + app names
- **`README.md`** — title, description, and `git clone` URL updated to the new repo name

## Downstream impact

- Docker image published to Docker Hub will now be `io2060/hologram-ai-agent:<tag>` (CD workflow + release-please will produce the new tag from this repo).
- Helm chart published to OCI will now be `oci://registry-1.docker.io/io2060/hologram-ai-agent-chart`.
- The `hologram-docs` and `hologram-sandbox-agent-example` repos already reference the new image / chart names, so no further coordination is needed there.

## Notes

- `version` stays at `1.13.0` (unchanged from `main` — no version bump needed for a name-only change; release-please will handle the next bump on the next release).
- Two unrelated WIP artifacts (`docs/vsa-initial-spec.md`, `mcp-smoke.mjs`) that were sitting untracked in the working tree are intentionally **not** included in this PR — they belong in their own change sets.
