### PR TITLE
fix(cd): publish Docker image as hologram-ai-agent

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 env:
-  IMAGE_NAME: 'hologram-generic-ai-agent-app'
+  IMAGE_NAME: 'hologram-ai-agent'
 
 jobs:
   resolve-version:


### PR DESCRIPTION
## Why

PR #90 renamed the package, the Helm chart, and the chart's default image repository to `hologram-ai-agent`, but `cd.yml` still had a hardcoded `IMAGE_NAME: 'hologram-generic-ai-agent-app'` at the top. Without this fix, the next release would still publish the Docker image to `io2060/hologram-generic-ai-agent-app:vX.Y.Z`, defeating the rename.

## What

```diff
 env:
-  IMAGE_NAME: 'hologram-generic-ai-agent-app'
+  IMAGE_NAME: 'hologram-ai-agent'
```

## Effect on the next release

This commit uses the `fix:` Conventional Commit prefix, so once merged release-please will:

1. Open a `chore(main): release 1.13.1` PR.
2. On merging that release PR, CD will:
   - Build & push `io2060/hologram-ai-agent:v1.13.1`, `io2060/hologram-ai-agent:latest`, etc. (instead of `io2060/hologram-generic-ai-agent-app:*`).
   - Push the Helm chart to `oci://docker.io/io2060/hologram-ai-agent-chart:1.13.1`.

After this release, every external reference (`hologram-docs`, `hologram-sandbox-agent-example`'s `deployment.yaml`) will resolve correctly.

## Notes

- No code changes — workflow only.
- This finishes the rename started in #90.
